### PR TITLE
Please review new version of the iOS Sample App (Obj-C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ This app demonstrates Singular's best practices for implementing the iOS SDK.
 
 This sample contains examples of:
 
-- Initializing the SDK
+- Initializing the Singular Config Object
+- Setting Config Options
 - Setting custom user id
 - Sending custom events
-- Sending simple revenue events
-- Handling deep links / deferred deep links
+- Sending revenue events
+- Handling deep links / deferred deep links & passthroughs
 - Support ESP Domain
+- Supporting Global Properties
 
 ## Getting Started
 To run the sample app you'll have to configure your own API Key / Secret as follows:
@@ -18,3 +20,7 @@ To run the sample app you'll have to configure your own API Key / Secret as foll
 1. Retrieve the API Key & Secret from your account's SDK Keys page
 2. Open the ios-sample-app project in XCode
 3. Go to the Constants.h file and replace the values of `APIKEY` & `SECRET` with your credentials
+4. Update your Associated Domain capabilitiy per: https://support.singular.net/hc/en-us/articles/360031371451-Singular-Links-Prerequisites?navigation_side_bar=true
+5. Update your URL scheme in the Target App > Info > URL Types
+6. Update the bundle identifier in the Target App > General tab to something unqiue
+7. Add the Push Notification capability per: https://support.singular.net/hc/en-us/articles/360000269811-Uninstall-Tracking-APNS-Apple-Push-Notification-Service

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This sample contains examples of:
 - Sending custom events
 - Sending simple revenue events
 - Handling deep links / deferred deep links
+- Support ESP Domain
 
 ## Getting Started
 To run the sample app you'll have to configure your own API Key / Secret as follows:

--- a/ios-sample-app/Singular-SDK/Singular.h
+++ b/ios-sample-app/Singular-SDK/Singular.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <WebKit/WebKit.h>
+#import "SingularAdData.h"
 
 // avoid circular include of SingularLinkParams
 #ifndef SingularLinkParams
@@ -100,6 +101,7 @@
 + (void)unsetCustomUserId;
 
 + (void)setSessionTimeout:(int)timeout;
++ (NSInteger)getFirstSessionUnixTime;
 
 + (void)setWrapperName:(NSString*)name andVersion:(NSString*)version;
 
@@ -125,5 +127,13 @@
 + (void)skanRegisterAppForAdNetworkAttribution;
 + (BOOL)skanUpdateConversionValue:(NSInteger)conversionValue;
 + (NSNumber *)skanGetConversionValue;
+
+/* Singular Links */
+
++(BOOL)isSingularLink:(id)linkHolder;
+
+/* Admon Methods*/
+
++ (void)adRevenue:(SingularAdData*)adData;
 
 @end

--- a/ios-sample-app/Singular-SDK/SingularConfig.h
+++ b/ios-sample-app/Singular-SDK/SingularConfig.h
@@ -25,6 +25,7 @@
 @property void(^singularLinksHandler)(SingularLinkParams*);
 @property long shortLinkResolveTimeOut;
 @property NSArray* supportedDomains;
+@property NSArray* espDomains;
 
 // Global Properties fields
 @property (readonly) NSMutableDictionary* globalProperties;
@@ -38,5 +39,6 @@
 -(id)initWithApiKey:(NSString*)apikey andSecret:(NSString*)secret;
 
 -(void)setGlobalProperty:(NSString*)key withValue:(NSString*)value overrideExisting:(BOOL)overrideExisiting;
+-(NSString*)toJsonString;
 
 @end

--- a/ios-sample-app/ios-sample-app.xcodeproj/project.pbxproj
+++ b/ios-sample-app/ios-sample-app.xcodeproj/project.pbxproj
@@ -7,27 +7,29 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		21626744238431F10019FD74 /* libsqlite3.0.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 21626743238431F10019FD74 /* libsqlite3.0.tbd */; };
-		21626746238431F80019FD74 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21626745238431F80019FD74 /* SystemConfiguration.framework */; };
-		21626748238432010019FD74 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21626747238432010019FD74 /* Security.framework */; };
-		2162674A238432070019FD74 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 21626749238432070019FD74 /* libz.tbd */; };
-		2162674C2384320C0019FD74 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2162674B2384320C0019FD74 /* AdSupport.framework */; };
-		2162674E238432110019FD74 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2162674D238432110019FD74 /* iAd.framework */; };
-		216267542384340D0019FD74 /* libSingular.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 216267502384340D0019FD74 /* libSingular.a */; };
-		216267552384340D0019FD74 /* Singular.js in Resources */ = {isa = PBXBuildFile; fileRef = 216267512384340D0019FD74 /* Singular.js */; };
 		2162675823843BE70019FD74 /* CustomEventsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2162675723843BE70019FD74 /* CustomEventsController.m */; };
 		2162675C2384464C0019FD74 /* RevenueController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2162675B2384464C0019FD74 /* RevenueController.m */; };
 		21626765238559130019FD74 /* TabController.m in Sources */ = {isa = PBXBuildFile; fileRef = 21626764238559130019FD74 /* TabController.m */; };
 		2162676C238566C00019FD74 /* DeeplinkController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2162676B238566C00019FD74 /* DeeplinkController.m */; };
 		216267732386BCA60019FD74 /* Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 216267722386BCA60019FD74 /* Utils.m */; };
-		216EAB98261F20B00085D00C /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 216EAB97261F20B00085D00C /* AdServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		21A3D9C12393D89300290460 /* IdentityController.m in Sources */ = {isa = PBXBuildFile; fileRef = 21A3D9C02393D89300290460 /* IdentityController.m */; };
 		21DB6DB4237C036B008E845A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 21DB6DB3237C036B008E845A /* AppDelegate.m */; };
 		21DB6DBD237C036B008E845A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 21DB6DBB237C036B008E845A /* Main.storyboard */; };
 		21DB6DBF237C036E008E845A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 21DB6DBE237C036E008E845A /* Assets.xcassets */; };
 		21DB6DC2237C036E008E845A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 21DB6DC0237C036E008E845A /* LaunchScreen.storyboard */; };
 		21DB6DC5237C036E008E845A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 21DB6DC4237C036E008E845A /* main.m */; };
-		27D1C9D924DC57120023B35F /* AppTrackingTransparency.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27D1C9D824DC57120023B35F /* AppTrackingTransparency.framework */; };
+		7F4265F126EBE17E00577CA9 /* Singular.js in Resources */ = {isa = PBXBuildFile; fileRef = 7F4265EC26EBE17E00577CA9 /* Singular.js */; };
+		7F4265F226EBE5A900577CA9 /* libsqlite3.0.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 21626743238431F10019FD74 /* libsqlite3.0.tbd */; };
+		7F4265F326EBE5B000577CA9 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21626745238431F80019FD74 /* SystemConfiguration.framework */; };
+		7F4265F426EBE5B700577CA9 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21626747238432010019FD74 /* Security.framework */; };
+		7F4265F526EBE5C000577CA9 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 21626749238432070019FD74 /* libz.tbd */; };
+		7F4265F626EBE5C700577CA9 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2162674B2384320C0019FD74 /* AdSupport.framework */; };
+		7F4265F726EBE5CF00577CA9 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2162674D238432110019FD74 /* iAd.framework */; };
+		7F4265F926EBE5D700577CA9 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F4265F826EBE5D700577CA9 /* WebKit.framework */; };
+		7F4265FB26EBE5DF00577CA9 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F4265FA26EBE5DF00577CA9 /* StoreKit.framework */; };
+		7F4265FC26EBE5E600577CA9 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 216EAB97261F20B00085D00C /* AdServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		7F78C31F2728D58400838455 /* libSingular.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F4265FD26EBE8C800577CA9 /* libSingular.a */; };
+		7F78C3212728EA3100838455 /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F78C3202728EA3100838455 /* UserNotifications.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -37,10 +39,6 @@
 		21626749238432070019FD74 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		2162674B2384320C0019FD74 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		2162674D238432110019FD74 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
-		216267502384340D0019FD74 /* libSingular.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libSingular.a; sourceTree = "<group>"; };
-		216267512384340D0019FD74 /* Singular.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = Singular.js; sourceTree = "<group>"; };
-		216267522384340D0019FD74 /* SingularLinkParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingularLinkParams.h; sourceTree = "<group>"; };
-		216267532384340D0019FD74 /* Singular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Singular.h; sourceTree = "<group>"; };
 		2162675623843BE70019FD74 /* CustomEventsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomEventsController.h; sourceTree = "<group>"; };
 		2162675723843BE70019FD74 /* CustomEventsController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomEventsController.m; sourceTree = "<group>"; };
 		2162675A2384464C0019FD74 /* RevenueController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RevenueController.h; sourceTree = "<group>"; };
@@ -64,6 +62,16 @@
 		21DB6DC3237C036E008E845A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		21DB6DC4237C036E008E845A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		27D1C9D824DC57120023B35F /* AppTrackingTransparency.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppTrackingTransparency.framework; path = System/Library/Frameworks/AppTrackingTransparency.framework; sourceTree = SDKROOT; };
+		7F4265EA26EBE17E00577CA9 /* SingularConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingularConfig.h; sourceTree = "<group>"; };
+		7F4265EB26EBE17E00577CA9 /* libSingular.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libSingular.a; sourceTree = "<group>"; };
+		7F4265EC26EBE17E00577CA9 /* Singular.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = Singular.js; sourceTree = "<group>"; };
+		7F4265ED26EBE17E00577CA9 /* SingularLinkParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingularLinkParams.h; sourceTree = "<group>"; };
+		7F4265EE26EBE17E00577CA9 /* SingularAdData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingularAdData.h; sourceTree = "<group>"; };
+		7F4265EF26EBE17E00577CA9 /* Singular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Singular.h; sourceTree = "<group>"; };
+		7F4265F826EBE5D700577CA9 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		7F4265FA26EBE5DF00577CA9 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
+		7F4265FD26EBE8C800577CA9 /* libSingular.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSingular.a; path = "Singular-SDK/libSingular.a"; sourceTree = "<group>"; };
+		7F78C3202728EA3100838455 /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,15 +79,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				216EAB98261F20B00085D00C /* AdServices.framework in Frameworks */,
-				27D1C9D924DC57120023B35F /* AppTrackingTransparency.framework in Frameworks */,
-				2162674E238432110019FD74 /* iAd.framework in Frameworks */,
-				2162674C2384320C0019FD74 /* AdSupport.framework in Frameworks */,
-				2162674A238432070019FD74 /* libz.tbd in Frameworks */,
-				21626748238432010019FD74 /* Security.framework in Frameworks */,
-				21626746238431F80019FD74 /* SystemConfiguration.framework in Frameworks */,
-				21626744238431F10019FD74 /* libsqlite3.0.tbd in Frameworks */,
-				216267542384340D0019FD74 /* libSingular.a in Frameworks */,
+				7F78C3212728EA3100838455 /* UserNotifications.framework in Frameworks */,
+				7F78C31F2728D58400838455 /* libSingular.a in Frameworks */,
+				7F4265FC26EBE5E600577CA9 /* AdServices.framework in Frameworks */,
+				7F4265FB26EBE5DF00577CA9 /* StoreKit.framework in Frameworks */,
+				7F4265F926EBE5D700577CA9 /* WebKit.framework in Frameworks */,
+				7F4265F726EBE5CF00577CA9 /* iAd.framework in Frameworks */,
+				7F4265F626EBE5C700577CA9 /* AdSupport.framework in Frameworks */,
+				7F4265F526EBE5C000577CA9 /* libz.tbd in Frameworks */,
+				7F4265F426EBE5B700577CA9 /* Security.framework in Frameworks */,
+				7F4265F326EBE5B000577CA9 /* SystemConfiguration.framework in Frameworks */,
+				7F4265F226EBE5A900577CA9 /* libsqlite3.0.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,6 +99,10 @@
 		21626742238431F10019FD74 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				7F78C3202728EA3100838455 /* UserNotifications.framework */,
+				7F4265FD26EBE8C800577CA9 /* libSingular.a */,
+				7F4265FA26EBE5DF00577CA9 /* StoreKit.framework */,
+				7F4265F826EBE5D700577CA9 /* WebKit.framework */,
 				216EAB97261F20B00085D00C /* AdServices.framework */,
 				27D1C9D824DC57120023B35F /* AppTrackingTransparency.framework */,
 				2162674D238432110019FD74 /* iAd.framework */,
@@ -99,17 +113,6 @@
 				21626743238431F10019FD74 /* libsqlite3.0.tbd */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		2162674F2384340D0019FD74 /* Singular-SDK */ = {
-			isa = PBXGroup;
-			children = (
-				216267502384340D0019FD74 /* libSingular.a */,
-				216267512384340D0019FD74 /* Singular.js */,
-				216267522384340D0019FD74 /* SingularLinkParams.h */,
-				216267532384340D0019FD74 /* Singular.h */,
-			);
-			path = "Singular-SDK";
 			sourceTree = "<group>";
 		};
 		21626759238444350019FD74 /* Controllers */ = {
@@ -132,7 +135,6 @@
 		21DB6DA6237C036B008E845A = {
 			isa = PBXGroup;
 			children = (
-				2162674F2384340D0019FD74 /* Singular-SDK */,
 				21DB6DB1237C036B008E845A /* ios-sample-app */,
 				21DB6DB0237C036B008E845A /* Products */,
 				21626742238431F10019FD74 /* Frameworks */,
@@ -150,6 +152,7 @@
 		21DB6DB1237C036B008E845A /* ios-sample-app */ = {
 			isa = PBXGroup;
 			children = (
+				7F4265E926EBE17E00577CA9 /* Singular-SDK */,
 				21626759238444350019FD74 /* Controllers */,
 				21DB6DB2237C036B008E845A /* AppDelegate.h */,
 				21DB6DB3237C036B008E845A /* AppDelegate.m */,
@@ -163,6 +166,19 @@
 				21DB6DC4237C036E008E845A /* main.m */,
 			);
 			path = "ios-sample-app";
+			sourceTree = "<group>";
+		};
+		7F4265E926EBE17E00577CA9 /* Singular-SDK */ = {
+			isa = PBXGroup;
+			children = (
+				7F4265EA26EBE17E00577CA9 /* SingularConfig.h */,
+				7F4265EB26EBE17E00577CA9 /* libSingular.a */,
+				7F4265EC26EBE17E00577CA9 /* Singular.js */,
+				7F4265ED26EBE17E00577CA9 /* SingularLinkParams.h */,
+				7F4265EE26EBE17E00577CA9 /* SingularAdData.h */,
+				7F4265EF26EBE17E00577CA9 /* Singular.h */,
+			);
+			path = "Singular-SDK";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -191,7 +207,7 @@
 		21DB6DA7237C036B008E845A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1110;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "Singular Labs";
 				TargetAttributes = {
 					21DB6DAE237C036B008E845A = {
@@ -225,7 +241,7 @@
 				21DB6DC2237C036E008E845A /* LaunchScreen.storyboard in Resources */,
 				21DB6DBF237C036E008E845A /* Assets.xcassets in Resources */,
 				21DB6DBD237C036B008E845A /* Main.storyboard in Resources */,
-				216267552384340D0019FD74 /* Singular.js in Resources */,
+				7F4265F126EBE17E00577CA9 /* Singular.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -295,6 +311,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -319,7 +336,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LIBRARY_SEARCH_PATHS = "${PROJECT_DIR}/Singular-SDK";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -354,6 +371,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -372,7 +390,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LIBRARY_SEARCH_PATHS = "${PROJECT_DIR}/Singular-SDK";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -388,7 +406,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ios-sample-app/iOS Sample App.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = DZG6XY7PWJ;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "ios-sample-app/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -398,7 +416,9 @@
 					"${PROJECT_DIR}/Singular-SDK",
 					"$(PROJECT_DIR)/Singular-SDK",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = ios.sample.app;
+				MARKETING_VERSION = 2.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = ios.sample.app.objc;
 				PRODUCT_NAME = iOSSampleApp;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -412,7 +432,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ios-sample-app/iOS Sample App.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = S84G4K2QJ2;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "ios-sample-app/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -422,7 +442,9 @@
 					"${PROJECT_DIR}/Singular-SDK",
 					"$(PROJECT_DIR)/Singular-SDK",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = ios.sample.app4;
+				MARKETING_VERSION = 2.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = ios.sample.app.objc;
 				PRODUCT_NAME = iOSSampleApp;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios-sample-app/ios-sample-app/AppDelegate.h
+++ b/ios-sample-app/ios-sample-app/AppDelegate.h
@@ -3,17 +3,27 @@
 //  ios-sample-app
 //
 //  Created by Eyal Rabinovich on 13/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>
+#import <UserNotifications/UserNotifications.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>{
+@interface AppDelegate : UIResponder <UIApplicationDelegate, UNUserNotificationCenterDelegate>{
     NSDictionary* deeplinkData;
+    NSString* att_state;
+    NSString* s_idfa;
+    NSString* s_idfv;
+    NSString* sharedMessage;
 }
 
 @property (strong, nonatomic) UIWindow *window;
 @property (nonatomic, retain) NSDictionary* deeplinkData;
+@property (nonatomic, retain) NSString* att_state;
+@property (nonatomic, retain) NSString* s_idfa;
+@property (nonatomic, retain) NSString* s_idfv;
+@property (nonatomic, retain) NSString* sharedMessage;
 
 @end
 

--- a/ios-sample-app/ios-sample-app/AppDelegate.m
+++ b/ios-sample-app/ios-sample-app/AppDelegate.m
@@ -3,8 +3,25 @@
 //  ios-sample-app
 //
 //  Created by Eyal Rabinovich on 13/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
+/*
+ This sample app illustrates working examples of a Singular implementation in Obj-C.
+ Console Logging and Event have been configured to out activity to the Singular SDK Console.
+ To build this App you must:
+    1. update your SDK Key and Secret in the Constants File.
+    2. update your Associated Domain capabilitiy per: https://support.singular.net/hc/en-us/articles/360031371451-Singular-Links-Prerequisites?navigation_side_bar=true
+    3. update your URL scheme in the Target App > Info > URL Types
+    4. update the bundle identifier in the Target App > General tab to something unqiue
+    5. Add the Push Notification capability per: https://support.singular.net/hc/en-us/articles/360000269811-Uninstall-Tracking-APNS-Apple-Push-Notification-Service
+ 
+ You will find a View Controller illustrating each method to invoke Events and Revenue events. Examples
+ are provided where possible.
+ 
+ The Identity Controller will demonstrate the methods for Data Privacy and allows you to share
+ your identifiers or test purposes.
+*/
 
 #import "AppDelegate.h"
 #import <UIKit/UIKit.h>
@@ -12,19 +29,32 @@
 #import "Utils.h"
 #import "TabController.h"
 #import "Constants.h"
+#import <AdServices/AdServices.h>
 
+#import <UserNotifications/UserNotifications.h>
 #import <AppTrackingTransparency/ATTrackingManager.h>
 #import <AdSupport/ASIdentifierManager.h>
 
-@interface AppDelegate ()
+#define SYSTEM_VERSION_GRATERTHAN_OR_EQUALTO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 
+@interface AppDelegate ()
 @end
 
 @implementation AppDelegate
 
 @synthesize deeplinkData;
+@synthesize att_state;
+@synthesize s_idfa;
+@synthesize s_idfv;
+@synthesize sharedMessage;
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Request user consent to use the Advertising Identifier (idfa)
+    [self requestTrackingAuthorization];
+}
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    NSLog(@"SDK Version: %@", Singular.version);
     
     // If your app uses scenes and you want to support Singular Links, please refer to the documentation here:
     // https://support.singular.net/hc/en-us/articles/360038341692
@@ -32,93 +62,159 @@
     // Starts a new session when the user opens the app if the session timeout has passed / opened using a Singular Link
     SingularConfig *config = [self getConfig];
     config.launchOptions = launchOptions;
-    
-    // Will be zeros (unless tracking consent was given in a previous session)
-    NSString *idfaString = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
-
     [Singular start:config];
     
-    // Request user consent to use the Advertising Identifier (idfa)
-    [self requestTrackingAuthorization];
-    
-    idfaString = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+    // This code block will Register for Push Notifications to obtain Token for Uninstall Tracking.
+    NSError *error = nil;
+    Class AAAttributionClass = NSClassFromString(@"AAAttribution");
+    if (AAAttributionClass) {
+        NSString *attributionToken = [AAAttributionClass attributionTokenWithError:&error];
+        if (!error && attributionToken) {
+            NSLog(@"AdServices attribution_token: %@", attributionToken);
+        }
+    }
+    [[UIApplication sharedApplication] registerForRemoteNotifications];
     
     return YES;
 }
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity
  restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> *restorableObjects))restorationHandler {
-    
     // Starts a new session when the user opens the app using a Singular Link while it was in the background
     SingularConfig *config = [self getConfig];
     config.userActivity = userActivity;
-    
     [Singular start:config];
-    
-    // Request user consent to use the Advertising Identifier (idfa)
-    [self requestTrackingAuthorization];
 
     return YES;
 }
 
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options{
+    // Starts a new session when the user opens the app using a Non Singular Link, like a traditional App scheme.
+    // This code block will provide the Non Singular link value to the Singular Deeplink Handler
+    SingularConfig *config = [self getConfig];
+    [Singular start:config];
+    
+    // Replace this code with your own logic to handle Non Singular Links
+    NSLog(@"Handle URL: %@", url);
+    NSString *deeplink = url.absoluteString;
+    if (deeplink == (id)[NSNull null] || deeplink.length == 0 ) deeplink = @"";
+    NSMutableDictionary* values = [[NSMutableDictionary alloc] init];
+    [values setObject:deeplink forKey:DEEPLINK];
+    self.deeplinkData = values;
+    [self navigateToDeeplinkController];
+    
+    return YES;
+}
+
 - (SingularConfig *)getConfig {
+    // Singular Configuration
+    
+    // Optional: Modifying the Session Timeout
+    // By default, if the app runs in the background for 60 seconds or more before returning
+    // to the foreground, the SDK registers a new session.
+    //[Singular setSessionTimeout:60];
+    
+    // Optional: Setting the Custom User ID
+    // If you already know the user ID when the app opens, set it before initializing the
+    // Singular SDK. This way, Singular will have the user ID from the very first session.
+    // Otherwise, set the user ID during Authentication.
+    //[Singular setCustomUserId:@"a_user_id"];
+    
+    // Invoke the Config Object
     SingularConfig *config = [[SingularConfig alloc] initWithApiKey:APIKEY andSecret:SECRET];
     
+    // Initialize the Singular Links Handler and Callback to retreive the deeplink or deferred
+    // deeplink values.
     config.singularLinksHandler = ^(SingularLinkParams * params) {
         [self handleSingularLink:params];
     };
-    
-    // Enable use of SKAN for iOS14 tracking
-    // Singular will call registerAppForAdNetworkAttribution for you
-    // Invoking [Singular skanRegisterAppForAdNetworkAttribution] will set this value to YES, even if done before/after [Singular start]
+        
+    // Enable skAdNetwork support for iOS14+ tracking. Singular will call
+    // registerAppForAdNetworkAttribution for you.
     config.skAdNetworkEnabled = YES;
     
-    // Enable manual conversion value updates
-    // IMPORTANT: set as NO (or just don't set - it defaults to NO) to let Singular manage conversion values
-    config.manualSkanConversionManagement = YES;
+    // Optional: To enable manual conversion value updates, set this to YES
+    // IMPORTANT: The default is NO, allowing Singular to manage your Conversion Values.
+    //config.manualSkanConversionManagement = YES;
     
+    // Optional: Receive a callback whenever the Conversion Value is updated
     config.conversionValueUpdatedCallback = ^(NSInteger newConversionValue) {
-      // Receive a callback whenever the Conversion Value is updated
+        NSLog(@"Conversion Value Callback: %lu", (unsigned long)newConversionValue);
     };
     
-    // Delay sending events for up to 3 minutes, or until Tracking is Authorized (only on iOS 14)
-    config.waitForTrackingAuthorizationWithTimeoutInterval = 180;
+    // Optional: To delay the firing of a user session, you can initialize the Singular SDK
+    // with the waitForTrackingAuthorizationWithTimeoutInterval. Singular will then start the
+    // attribution process, taking advantage of the IDFA if it is available or using probabilistic
+    // attribution if the IDFA is not available. Delay sending events for up to 3 minutes,
+    // or until Tracking is Authorized (only on iOS 14)
+    config.waitForTrackingAuthorizationWithTimeoutInterval = 300;
+    
+    // Optional: Setting Global Properties through SingularConfig
+    // You can define up to 5 global properties.
+    // They persist between app runs (with the latest value you gave them) until you unset them
+    // or the user uninstalls the app.
+    // Each property name and value can be up to 200 characters long. If you pass a longer property
+    // name or value, it will be truncated to 200 characters.
+    //
+    // Note that since global properties and their values persist between app runs, the property
+    // that you are setting may already be set to a different value. Use the overrideExisting
+    // parameter to tell the SDK whether to override an existing property with the new value or not.
+    [config setGlobalProperty:@"example_key" withValue:@"example_value" overrideExisting:YES];
     
     return config;
 }
 
-- (void)requestTrackingAuthorization {
-    if (@available(iOS 14, *)) {
-        // call requestTrackingAuthorizationWithCompletionHandler from ATTrackingManager to start the user consent process
-        [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status){
-            // your authorization handler here
-            // note: the Singular SDK will automatically detect if authorization has been given and initialize itself
-        }];
-    }
-}
-
+// This is function will parse the parameters from a Singular Link or from the Response of
+// the first session to provide the deeplink, deferred deeplink, and passthrough values.
 - (void)handleSingularLink:(SingularLinkParams*)params{
+    NSLog(@"\n**** - handleSingularLink - ****\n");
+    NSString* deeplink = [params getDeepLink];
+    NSString* passthrough = [params getPassthrough];
+    BOOL isDeferredDeeplink = [params isDeferred];
+    
+    // Handle the Deeplink and Passthorugh Values
+    if (deeplink == (id)[NSNull null] || deeplink.length == 0 ) deeplink = @"";
+    if (passthrough == (id)[NSNull null] || passthrough.length == 0 ) passthrough = @"";
+    NSLog(@"Deeplink: %@", deeplink);
+    NSLog(@"Passthrough: %@", passthrough);
+    
     NSMutableDictionary* values = [[NSMutableDictionary alloc] init];
-    
-    [values setObject:[params getDeepLink] forKey:DEEPLINK];
-    [values setObject:[params getPassthrough] forKey:PASSTHROUGH];
-    [values setObject:[NSNumber numberWithBool:[params isDeferred]] forKey:IS_DEFERRED];
-    
+    [values setObject:deeplink forKey:DEEPLINK];
+    [values setObject:passthrough forKey:PASSTHROUGH];
+    [values setObject:[NSNumber numberWithBool:isDeferredDeeplink] forKey:IS_DEFERRED];
     self.deeplinkData = values;
-    
     [self navigateToDeeplinkController];
 }
 
+// This function opens the deeplink view controller to display the provided deeplink data
 -(void)navigateToDeeplinkController{
-    
     // UI changes must run on main thread
     dispatch_async(dispatch_get_main_queue(), ^{
         TabController* tabBar = (TabController*)self.window.rootViewController;
-    
-        // Signal to the TabController the app opened using a Singular Link
         [tabBar openedWithDeeplink];
     });
 }
 
-@end
+// This function is used to display the ATT Pop up for consent. It is assumed that your App is already managing ATT.
+- (void)requestTrackingAuthorization {
+    if (@available(iOS 14, *)) {
+        [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
+            // Tracking authorization completed. Start loading ads here.
+            NSLog(@"ATT Requested");
+          }];
+    }
+}
 
+// Handle remote notification registration.
+- (void)application:(UIApplication *)app didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)devToken {
+    // This is used to forward the token to Singular for Uninstall Tracking
+    [Singular registerDeviceTokenForUninstall:devToken];
+}
+
+- (void)application:(UIApplication *)app didFailToRegisterForRemoteNotificationsWithError:(NSError *)err {
+    // The token is not currently available.
+    NSLog(@"Remote notification support is unavailable due to error: %@", err);
+    //[self disableRemoteNotificationFeatures];
+}
+
+@end

--- a/ios-sample-app/ios-sample-app/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios-sample-app/ios-sample-app/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,93 +1,153 @@
 {
   "images" : [
     {
-      "idiom" : "iphone",
       "size" : "20x20",
+      "idiom" : "iphone",
+      "filename" : "Icon-App-20x20@2x.png",
       "scale" : "2x"
     },
     {
-      "idiom" : "iphone",
       "size" : "20x20",
+      "idiom" : "iphone",
+      "filename" : "Icon-App-20x20@3x.png",
       "scale" : "3x"
     },
     {
-      "idiom" : "iphone",
       "size" : "29x29",
+      "idiom" : "iphone",
+      "filename" : "Icon-App-29x29@1x.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "iphone",
+      "filename" : "Icon-App-29x29@2x.png",
       "scale" : "2x"
     },
     {
-      "idiom" : "iphone",
       "size" : "29x29",
+      "idiom" : "iphone",
+      "filename" : "Icon-App-29x29@3x.png",
       "scale" : "3x"
     },
     {
-      "idiom" : "iphone",
       "size" : "40x40",
+      "idiom" : "iphone",
+      "filename" : "Icon-App-40x40@2x.png",
       "scale" : "2x"
     },
     {
-      "idiom" : "iphone",
       "size" : "40x40",
+      "idiom" : "iphone",
+      "filename" : "Icon-App-40x40@3x.png",
       "scale" : "3x"
     },
     {
+      "size" : "57x57",
       "idiom" : "iphone",
+      "filename" : "Icon-App-57x57@1x.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "57x57",
+      "idiom" : "iphone",
+      "filename" : "Icon-App-57x57@2x.png",
+      "scale" : "2x"
+    },
+    {
       "size" : "60x60",
+      "idiom" : "iphone",
+      "filename" : "Icon-App-60x60@2x.png",
       "scale" : "2x"
     },
     {
-      "idiom" : "iphone",
       "size" : "60x60",
+      "idiom" : "iphone",
+      "filename" : "Icon-App-60x60@3x.png",
       "scale" : "3x"
     },
     {
-      "idiom" : "ipad",
       "size" : "20x20",
+      "idiom" : "ipad",
+      "filename" : "Icon-App-20x20@1x.png",
       "scale" : "1x"
     },
     {
-      "idiom" : "ipad",
       "size" : "20x20",
+      "idiom" : "ipad",
+      "filename" : "Icon-App-20x20@2x.png",
       "scale" : "2x"
     },
     {
-      "idiom" : "ipad",
       "size" : "29x29",
+      "idiom" : "ipad",
+      "filename" : "Icon-App-29x29@1x.png",
       "scale" : "1x"
     },
     {
-      "idiom" : "ipad",
       "size" : "29x29",
+      "idiom" : "ipad",
+      "filename" : "Icon-App-29x29@2x.png",
       "scale" : "2x"
     },
     {
-      "idiom" : "ipad",
       "size" : "40x40",
+      "idiom" : "ipad",
+      "filename" : "Icon-App-40x40@1x.png",
       "scale" : "1x"
     },
     {
-      "idiom" : "ipad",
       "size" : "40x40",
+      "idiom" : "ipad",
+      "filename" : "Icon-App-40x40@2x.png",
       "scale" : "2x"
     },
     {
+      "size" : "50x50",
       "idiom" : "ipad",
-      "size" : "76x76",
+      "filename" : "Icon-Small-50x50@1x.png",
       "scale" : "1x"
     },
     {
+      "size" : "50x50",
       "idiom" : "ipad",
-      "size" : "76x76",
+      "filename" : "Icon-Small-50x50@2x.png",
       "scale" : "2x"
     },
     {
+      "size" : "72x72",
       "idiom" : "ipad",
+      "filename" : "Icon-App-72x72@1x.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "72x72",
+      "idiom" : "ipad",
+      "filename" : "Icon-App-72x72@2x.png",
+      "scale" : "2x"
+    },
+    {
+      "size" : "76x76",
+      "idiom" : "ipad",
+      "filename" : "Icon-App-76x76@1x.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "76x76",
+      "idiom" : "ipad",
+      "filename" : "Icon-App-76x76@2x.png",
+      "scale" : "2x"
+    },
+    {
       "size" : "83.5x83.5",
+      "idiom" : "ipad",
+      "filename" : "Icon-App-83.5x83.5@2x.png",
       "scale" : "2x"
     },
     {
-      "idiom" : "ios-marketing",
       "size" : "1024x1024",
+      "idiom" : "ios-marketing",
+      "filename" : "ItunesArtwork@2x.png",
       "scale" : "1x"
     }
   ],

--- a/ios-sample-app/ios-sample-app/Base.lproj/LaunchScreen.storyboard
+++ b/ios-sample-app/ios-sample-app/Base.lproj/LaunchScreen.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -15,13 +17,18 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="singular_full_logo" highlightedImage="singular_full_logo" translatesAutoresizingMaskIntoConstraints="NO" id="qTp-gm-2gs">
+                            <imageView opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" image="singular_full_logo" highlightedImage="singular_full_logo" translatesAutoresizingMaskIntoConstraints="NO" id="qTp-gm-2gs">
                                 <rect key="frame" x="33" y="251" width="308" height="164"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="qTp-gm-2gs" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="0qb-VL-o8f"/>
+                            <constraint firstItem="qTp-gm-2gs" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="251" id="AMi-gZ-5E0"/>
+                            <constraint firstItem="qTp-gm-2gs" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="33" id="iem-BX-Z6N"/>
+                            <constraint firstItem="qTp-gm-2gs" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="jBY-Ws-biX"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -31,5 +38,8 @@
     </scenes>
     <resources>
         <image name="singular_full_logo" width="786.5" height="192.5"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/ios-sample-app/ios-sample-app/Base.lproj/Main.storyboard
+++ b/ios-sample-app/ios-sample-app/Base.lproj/Main.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bDH-oN-Fc9">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bDH-oN-Fc9">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -19,10 +21,10 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
                     <connections>
-                        <segue destination="TFT-nu-jJc" kind="relationship" relationship="viewControllers" id="B1s-bc-hmW"/>
-                        <segue destination="Hhc-eO-b8x" kind="relationship" relationship="viewControllers" id="kgJ-0i-zEE"/>
                         <segue destination="OcW-9X-SqQ" kind="relationship" relationship="viewControllers" id="PSR-yz-1GC"/>
                         <segue destination="0ws-2Z-zEB" kind="relationship" relationship="viewControllers" id="rRw-d1-NK1"/>
+                        <segue destination="TFT-nu-jJc" kind="relationship" relationship="viewControllers" id="B1s-bc-hmW"/>
+                        <segue destination="Hhc-eO-b8x" kind="relationship" relationship="viewControllers" id="kgJ-0i-zEE"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pMP-cI-pEr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -34,43 +36,60 @@
             <objects>
                 <viewController id="TFT-nu-jJc" customClass="CustomEventsController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="RyV-4x-lPc">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="756"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Event Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2K0-e8-cE2">
-                                <rect key="frame" x="47" y="144" width="281" height="34"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lK1-M0-o1e">
-                                <rect key="frame" x="139" y="193" width="96" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lK1-M0-o1e">
+                                <rect key="frame" x="20" y="219.33333333333334" width="350" height="30"/>
                                 <state key="normal" title="Custom Event"/>
                                 <connections>
                                     <action selector="sendEvent:" destination="TFT-nu-jJc" eventType="touchUpInside" id="nUc-mG-KSI"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KoE-64-qzy">
-                                <rect key="frame" x="86" y="231" width="203" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Custom Event With Attributes"/>
+                            <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KoE-64-qzy">
+                                <rect key="frame" x="20" y="259.33333333333331" width="350" height="30"/>
+                                <state key="normal" title="Custom Event With Args"/>
                                 <connections>
-                                    <action selector="sendEventsWithAttributes:" destination="TFT-nu-jJc" eventType="touchUpInside" id="EeS-Xs-f3x"/>
+                                    <action selector="sendEventWithArgs:" destination="TFT-nu-jJc" eventType="touchUpInside" id="g3a-kv-SVm"/>
                                 </connections>
                             </button>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="singular_full_logo" translatesAutoresizingMaskIntoConstraints="NO" id="ogn-7J-9Y1">
-                                <rect key="frame" x="47" y="20" width="281" height="116"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="singular_full_logo" translatesAutoresizingMaskIntoConstraints="NO" id="ogn-7J-9Y1">
+                                <rect key="frame" x="47" y="20" width="296" height="128.33333333333334"/>
                             </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Send a Custom Event" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xnl-CY-7EV">
+                                <rect key="frame" x="20" y="178.33333333333334" width="350" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="la5-Gi-rV1">
+                                <rect key="frame" x="20" y="299.33333333333331" width="350" height="30"/>
+                                <state key="normal" title="Custom Event With Args in NSDictionary"/>
+                                <connections>
+                                    <action selector="sendEventsWithArgsWithDictionary:" destination="TFT-nu-jJc" eventType="touchUpInside" id="8s2-UO-JKu"/>
+                                </connections>
+                            </button>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="ObB-yu-yfJ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ObB-yu-yfJ" firstAttribute="trailing" secondItem="Xnl-CY-7EV" secondAttribute="trailing" constant="20" id="0gN-NS-TUs"/>
+                            <constraint firstItem="la5-Gi-rV1" firstAttribute="leading" secondItem="ObB-yu-yfJ" secondAttribute="leading" constant="20" id="9ix-bW-nKq"/>
+                            <constraint firstItem="ObB-yu-yfJ" firstAttribute="trailing" secondItem="KoE-64-qzy" secondAttribute="trailing" constant="20" id="APl-Hc-bQK"/>
+                            <constraint firstItem="ogn-7J-9Y1" firstAttribute="leading" secondItem="ObB-yu-yfJ" secondAttribute="leading" constant="47" id="Dox-2S-VzI"/>
+                            <constraint firstItem="ogn-7J-9Y1" firstAttribute="top" secondItem="ObB-yu-yfJ" secondAttribute="top" constant="20" id="Ogy-Fl-XgA"/>
+                            <constraint firstItem="Xnl-CY-7EV" firstAttribute="top" secondItem="ogn-7J-9Y1" secondAttribute="bottom" constant="30" id="T1A-gL-pl2"/>
+                            <constraint firstItem="KoE-64-qzy" firstAttribute="leading" secondItem="ObB-yu-yfJ" secondAttribute="leading" constant="20" id="cyF-oU-QYb"/>
+                            <constraint firstItem="lK1-M0-o1e" firstAttribute="leading" secondItem="ObB-yu-yfJ" secondAttribute="leading" constant="20" id="eq8-yW-dtk"/>
+                            <constraint firstItem="ObB-yu-yfJ" firstAttribute="trailing" secondItem="lK1-M0-o1e" secondAttribute="trailing" constant="20" id="gR2-N4-vXh"/>
+                            <constraint firstAttribute="trailing" secondItem="ogn-7J-9Y1" secondAttribute="trailing" constant="47" id="gVJ-CI-ZxI"/>
+                            <constraint firstItem="lK1-M0-o1e" firstAttribute="top" secondItem="Xnl-CY-7EV" secondAttribute="bottom" constant="20" id="jnR-5o-qrD"/>
+                            <constraint firstItem="KoE-64-qzy" firstAttribute="top" secondItem="lK1-M0-o1e" secondAttribute="bottom" constant="10" id="sJ9-fn-zMP"/>
+                            <constraint firstItem="ObB-yu-yfJ" firstAttribute="trailing" secondItem="la5-Gi-rV1" secondAttribute="trailing" constant="20" id="w2h-Ve-TtA"/>
+                            <constraint firstItem="Xnl-CY-7EV" firstAttribute="leading" secondItem="ObB-yu-yfJ" secondAttribute="leading" constant="20" id="yh0-Z7-XQ0"/>
+                            <constraint firstItem="la5-Gi-rV1" firstAttribute="top" secondItem="KoE-64-qzy" secondAttribute="bottom" constant="10" id="zDa-PF-eH9"/>
+                        </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Custom Events" image="pencil" catalog="system" selectedImage="pencil" id="lMn-F8-q1p"/>
-                    <connections>
-                        <outlet property="eventNameField" destination="2K0-e8-cE2" id="yiO-VF-eX2"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bBN-9g-dVx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -81,58 +100,95 @@
             <objects>
                 <viewController id="0ws-2Z-zEB" customClass="DeeplinkController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="rIt-xA-AWp">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="756"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="singular_full_logo" translatesAutoresizingMaskIntoConstraints="NO" id="zez-z4-0NV">
-                                <rect key="frame" x="47" y="20" width="281" height="116"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Deeplink" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8oa-Cf-ETI">
+                                <rect key="frame" x="20" y="198.33333333333334" width="350" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="K0v-kR-0WI"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Passthrough" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D0F-qU-tb4">
+                                <rect key="frame" x="20" y="300.33333333333331" width="350" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="wbP-He-hDx"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="App did not open with a deep link" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mHA-64-b0V">
+                                <rect key="frame" x="20" y="341.33333333333331" width="350" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="Lgz-6P-arI"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" systemColor="secondaryLabelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Is Deferred" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bdw-nH-i2U">
+                                <rect key="frame" x="20" y="402.33333333333331" width="350" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="0Yo-5f-pbi"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="App did not open with a deep link" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z5W-ew-EGO">
+                                <rect key="frame" x="20" y="239.33333333333334" width="350" height="21.000000000000028"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="UOL-IP-pgb"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" systemColor="secondaryLabelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="App did not open with a deep link" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WHc-f4-3Qm">
+                                <rect key="frame" x="20" y="443.33333333333331" width="350" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="GCg-jj-zDm"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" systemColor="secondaryLabelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="singular_full_logo" translatesAutoresizingMaskIntoConstraints="NO" id="k8k-nm-N58">
+                                <rect key="frame" x="47" y="20" width="296" height="128.33333333333334"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="128.33000000000001" id="ux4-5v-yEd"/>
+                                </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Deeplink" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8oa-Cf-ETI">
-                                <rect key="frame" x="47" y="144" width="281" height="20.5"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Passthrough" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D0F-qU-tb4">
-                                <rect key="frame" x="47" y="201" width="281" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="App did not open with a deep link" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mHA-64-b0V">
-                                <rect key="frame" x="47" y="230" width="281" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Is Deferred" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bdw-nH-i2U">
-                                <rect key="frame" x="47" y="259" width="281" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="App did not open with a deep link" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WHc-f4-3Qm">
-                                <rect key="frame" x="47" y="172" width="281" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="App did not open with a deep link" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z5W-ew-EGO">
-                                <rect key="frame" x="47" y="287" width="281" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="Roe-AL-X00"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Roe-AL-X00" firstAttribute="trailing" secondItem="bdw-nH-i2U" secondAttribute="trailing" constant="20" id="1en-FJ-tSE"/>
+                            <constraint firstItem="Roe-AL-X00" firstAttribute="trailing" secondItem="mHA-64-b0V" secondAttribute="trailing" constant="20" id="3xk-vr-5A9"/>
+                            <constraint firstItem="Roe-AL-X00" firstAttribute="trailing" secondItem="8oa-Cf-ETI" secondAttribute="trailing" constant="20" id="6GH-gQ-CyS"/>
+                            <constraint firstItem="WHc-f4-3Qm" firstAttribute="top" secondItem="bdw-nH-i2U" secondAttribute="bottom" constant="20" id="CfW-Xm-UJh"/>
+                            <constraint firstItem="z5W-ew-EGO" firstAttribute="leading" secondItem="Roe-AL-X00" secondAttribute="leading" constant="20" id="ISE-sy-mkd"/>
+                            <constraint firstItem="bdw-nH-i2U" firstAttribute="leading" secondItem="Roe-AL-X00" secondAttribute="leading" constant="20" id="KfP-i7-o4S"/>
+                            <constraint firstItem="Roe-AL-X00" firstAttribute="trailing" secondItem="z5W-ew-EGO" secondAttribute="trailing" constant="20" id="Mq3-9q-Hlc"/>
+                            <constraint firstItem="8oa-Cf-ETI" firstAttribute="top" secondItem="k8k-nm-N58" secondAttribute="bottom" constant="50" id="O81-ib-aP8"/>
+                            <constraint firstItem="mHA-64-b0V" firstAttribute="top" secondItem="D0F-qU-tb4" secondAttribute="bottom" constant="20" id="Qxa-vg-WZp"/>
+                            <constraint firstItem="WHc-f4-3Qm" firstAttribute="leading" secondItem="Roe-AL-X00" secondAttribute="leading" constant="20" id="Uah-ew-ldf"/>
+                            <constraint firstItem="8oa-Cf-ETI" firstAttribute="leading" secondItem="Roe-AL-X00" secondAttribute="leading" constant="20" id="V6t-Nm-jOb"/>
+                            <constraint firstItem="z5W-ew-EGO" firstAttribute="top" secondItem="8oa-Cf-ETI" secondAttribute="bottom" constant="20" id="WO1-Om-kDZ"/>
+                            <constraint firstItem="Roe-AL-X00" firstAttribute="trailing" secondItem="WHc-f4-3Qm" secondAttribute="trailing" constant="20" id="c9I-EQ-3EC"/>
+                            <constraint firstItem="Roe-AL-X00" firstAttribute="trailing" secondItem="k8k-nm-N58" secondAttribute="trailing" constant="47" id="fDH-WZ-ZYE"/>
+                            <constraint firstItem="D0F-qU-tb4" firstAttribute="leading" secondItem="Roe-AL-X00" secondAttribute="leading" constant="20" id="g8G-K9-t1m"/>
+                            <constraint firstItem="k8k-nm-N58" firstAttribute="top" secondItem="Roe-AL-X00" secondAttribute="top" constant="20" id="jvD-sJ-CqE"/>
+                            <constraint firstItem="k8k-nm-N58" firstAttribute="leading" secondItem="Roe-AL-X00" secondAttribute="leading" constant="47" id="oG5-52-FW1"/>
+                            <constraint firstItem="Roe-AL-X00" firstAttribute="trailing" secondItem="D0F-qU-tb4" secondAttribute="trailing" constant="20" id="oYJ-rV-0Zr"/>
+                            <constraint firstItem="D0F-qU-tb4" firstAttribute="top" secondItem="z5W-ew-EGO" secondAttribute="bottom" constant="40" id="qgJ-sv-uXA"/>
+                            <constraint firstItem="mHA-64-b0V" firstAttribute="leading" secondItem="Roe-AL-X00" secondAttribute="leading" constant="20" id="rHv-Z4-lnv"/>
+                            <constraint firstItem="bdw-nH-i2U" firstAttribute="top" secondItem="mHA-64-b0V" secondAttribute="bottom" constant="40" id="riZ-KC-t6r"/>
+                        </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Deep Links" image="link" catalog="system" selectedImage="link" id="i9B-Ye-rVx"/>
                     <connections>
@@ -150,118 +206,370 @@
             <objects>
                 <viewController id="Hhc-eO-b8x" customClass="RevenueController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="QWR-5L-cKP">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="756"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="singular_full_logo" translatesAutoresizingMaskIntoConstraints="NO" id="J9I-ef-2M9">
-                                <rect key="frame" x="47" y="20" width="281" height="116"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="singular_full_logo" translatesAutoresizingMaskIntoConstraints="NO" id="J9I-ef-2M9">
+                                <rect key="frame" x="47" y="20" width="296" height="128.33333333333334"/>
                             </imageView>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Revenue Event Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="p8z-RU-lL5">
-                                <rect key="frame" x="47" y="144" width="281" height="34"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Revenue" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9pM-0V-nEk">
-                                <rect key="frame" x="47" y="228" width="281" height="34"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Currency" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Avp-M6-Khs">
-                                <rect key="frame" x="47" y="186" width="281" height="34"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uBO-Te-RZ2">
+                                <rect key="frame" x="20" y="459.33333333333331" width="350" height="30"/>
+                                <state key="normal" title="CustomRevenue Event with Product Details">
+                                    <color key="titleColor" systemColor="linkColor"/>
+                                </state>
                                 <connections>
-                                    <action selector="showCurrencyPicker:" destination="Hhc-eO-b8x" eventType="editingDidBegin" id="07V-Rn-bSs"/>
-                                </connections>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uBO-Te-RZ2">
-                                <rect key="frame" x="83" y="315" width="209" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Revenue Event With Attributes"/>
-                                <connections>
-                                    <action selector="sendRevenueEventWithArgs:" destination="Hhc-eO-b8x" eventType="touchUpInside" id="y8A-tW-QQv"/>
+                                    <action selector="sendCustomRevenueWithProductDetailsEvent:" destination="Hhc-eO-b8x" eventType="touchUpInside" id="t65-LY-VaN"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r1l-3N-Igg">
-                                <rect key="frame" x="136" y="277" width="102" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Revenue Event"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r1l-3N-Igg">
+                                <rect key="frame" x="20" y="419.33333333333331" width="350" height="30"/>
+                                <state key="normal" title="CustomRevenue Event">
+                                    <color key="titleColor" systemColor="linkColor"/>
+                                </state>
                                 <connections>
-                                    <action selector="sendRevenueEvent:" destination="Hhc-eO-b8x" eventType="touchUpInside" id="0T6-5b-ntm"/>
+                                    <action selector="sendCustomRevenueEvent:" destination="Hhc-eO-b8x" eventType="touchUpInside" id="X9A-vK-iMt"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qgg-OR-Ja2">
+                                <rect key="frame" x="20" y="319.33333333333331" width="350" height="30"/>
+                                <state key="normal" title="Revenue (iap) Event">
+                                    <color key="titleColor" systemColor="linkColor"/>
+                                </state>
+                                <connections>
+                                    <action selector="sendRevenueEvent:" destination="Hhc-eO-b8x" eventType="touchUpInside" id="z3X-P7-FYY"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vhh-O6-Jja">
+                                <rect key="frame" x="20" y="359.33333333333331" width="350" height="30"/>
+                                <state key="normal" title="Revenue (iap) Event with Product Details">
+                                    <color key="titleColor" systemColor="linkColor"/>
+                                </state>
+                                <connections>
+                                    <action selector="sendRevenueWithProductDetailsEvent:" destination="Hhc-eO-b8x" eventType="touchUpInside" id="aSC-SO-Qix"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Send a Revenue Events" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ytF-TR-C7f">
+                                <rect key="frame" x="20" y="178.33333333333334" width="350" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Skx-WO-sQi">
+                                <rect key="frame" x="20" y="259.33333333333331" width="350" height="30"/>
+                                <state key="normal" title="iapCompleteWithName Event">
+                                    <color key="titleColor" systemColor="linkColor"/>
+                                </state>
+                                <connections>
+                                    <action selector="send_iapCompleteWithNameEvent:" destination="Hhc-eO-b8x" eventType="touchUpInside" id="9Qz-CN-xjd"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9N6-yO-JiT">
+                                <rect key="frame" x="20" y="219.33333333333334" width="350" height="30"/>
+                                <state key="normal" title="iapComplete Event">
+                                    <color key="titleColor" systemColor="linkColor"/>
+                                </state>
+                                <connections>
+                                    <action selector="send_iapCompleteEvent:" destination="Hhc-eO-b8x" eventType="touchUpInside" id="CvX-r0-DvC"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eVh-QK-vhQ">
+                                <rect key="frame" x="20" y="499.33333333333326" width="350" height="30"/>
+                                <state key="normal" title="CustomRevenueEventWithArgs">
+                                    <color key="titleColor" systemColor="linkColor"/>
+                                </state>
+                                <connections>
+                                    <action selector="sendRevenueEventWithArgs:" destination="Hhc-eO-b8x" eventType="touchUpInside" id="pXl-nc-oRd"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="Ivc-uT-hQZ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Ivc-uT-hQZ" firstAttribute="trailing" secondItem="vhh-O6-Jja" secondAttribute="trailing" constant="20" id="0hy-t3-8m4"/>
+                            <constraint firstItem="Qgg-OR-Ja2" firstAttribute="top" secondItem="Skx-WO-sQi" secondAttribute="bottom" constant="30" id="5nH-V6-HUB"/>
+                            <constraint firstItem="Ivc-uT-hQZ" firstAttribute="trailing" secondItem="ytF-TR-C7f" secondAttribute="trailing" constant="20" id="6Oz-2h-Ha7"/>
+                            <constraint firstItem="Qgg-OR-Ja2" firstAttribute="leading" secondItem="Ivc-uT-hQZ" secondAttribute="leading" constant="20" id="79s-29-bH5"/>
+                            <constraint firstItem="r1l-3N-Igg" firstAttribute="leading" secondItem="Ivc-uT-hQZ" secondAttribute="leading" constant="20" id="8eY-hL-hSf"/>
+                            <constraint firstItem="Ivc-uT-hQZ" firstAttribute="trailing" secondItem="eVh-QK-vhQ" secondAttribute="trailing" constant="20" id="9SW-tL-3A1"/>
+                            <constraint firstItem="uBO-Te-RZ2" firstAttribute="top" secondItem="r1l-3N-Igg" secondAttribute="bottom" constant="10" id="Bmu-fx-0rx"/>
+                            <constraint firstItem="Ivc-uT-hQZ" firstAttribute="trailing" secondItem="9N6-yO-JiT" secondAttribute="trailing" constant="20" id="G6Y-oF-LZT"/>
+                            <constraint firstItem="Skx-WO-sQi" firstAttribute="leading" secondItem="Ivc-uT-hQZ" secondAttribute="leading" constant="20" id="GGZ-7Z-Xmw"/>
+                            <constraint firstItem="Ivc-uT-hQZ" firstAttribute="trailing" secondItem="Qgg-OR-Ja2" secondAttribute="trailing" constant="20" id="ICk-58-Gcc"/>
+                            <constraint firstItem="eVh-QK-vhQ" firstAttribute="top" secondItem="uBO-Te-RZ2" secondAttribute="bottom" constant="10" id="If4-eg-9Ur"/>
+                            <constraint firstItem="r1l-3N-Igg" firstAttribute="top" secondItem="vhh-O6-Jja" secondAttribute="bottom" constant="30" id="J7y-tW-peh"/>
+                            <constraint firstItem="Skx-WO-sQi" firstAttribute="top" secondItem="9N6-yO-JiT" secondAttribute="bottom" constant="10" id="Jes-Ys-Hew"/>
+                            <constraint firstItem="J9I-ef-2M9" firstAttribute="top" secondItem="Ivc-uT-hQZ" secondAttribute="top" constant="20" id="Qyt-iS-yPT"/>
+                            <constraint firstItem="uBO-Te-RZ2" firstAttribute="leading" secondItem="Ivc-uT-hQZ" secondAttribute="leading" constant="20" id="RXn-l6-ETZ"/>
+                            <constraint firstItem="Ivc-uT-hQZ" firstAttribute="trailing" secondItem="uBO-Te-RZ2" secondAttribute="trailing" constant="20" id="Vwl-Pj-o2J"/>
+                            <constraint firstItem="Ivc-uT-hQZ" firstAttribute="trailing" secondItem="J9I-ef-2M9" secondAttribute="trailing" constant="47" id="W3d-bU-7Ad"/>
+                            <constraint firstItem="9N6-yO-JiT" firstAttribute="leading" secondItem="Ivc-uT-hQZ" secondAttribute="leading" constant="20" id="X2O-EV-GSq"/>
+                            <constraint firstItem="ytF-TR-C7f" firstAttribute="leading" secondItem="Ivc-uT-hQZ" secondAttribute="leading" constant="20" id="ckO-FJ-f80"/>
+                            <constraint firstItem="vhh-O6-Jja" firstAttribute="top" secondItem="Qgg-OR-Ja2" secondAttribute="bottom" constant="10" id="dTN-eh-zA6"/>
+                            <constraint firstItem="ytF-TR-C7f" firstAttribute="top" secondItem="J9I-ef-2M9" secondAttribute="bottom" constant="30" id="fAq-UH-3NI"/>
+                            <constraint firstItem="J9I-ef-2M9" firstAttribute="leading" secondItem="Ivc-uT-hQZ" secondAttribute="leading" constant="47" id="fGc-IK-byR"/>
+                            <constraint firstItem="vhh-O6-Jja" firstAttribute="leading" secondItem="Ivc-uT-hQZ" secondAttribute="leading" constant="20" id="jBm-WV-zwK"/>
+                            <constraint firstItem="Ivc-uT-hQZ" firstAttribute="trailing" secondItem="Skx-WO-sQi" secondAttribute="trailing" constant="20" id="mDB-M7-1T8"/>
+                            <constraint firstItem="9N6-yO-JiT" firstAttribute="top" secondItem="ytF-TR-C7f" secondAttribute="bottom" constant="20" id="pKC-ua-1uB"/>
+                            <constraint firstItem="eVh-QK-vhQ" firstAttribute="leading" secondItem="Ivc-uT-hQZ" secondAttribute="leading" constant="20" id="twZ-cY-Ju8"/>
+                            <constraint firstItem="Ivc-uT-hQZ" firstAttribute="trailing" secondItem="r1l-3N-Igg" secondAttribute="trailing" constant="20" id="w37-qs-orB"/>
+                        </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Revenue" image="dollarsign.circle.fill" catalog="system" selectedImage="dollarsign.circle.fill" id="sAb-zw-Nxe"/>
-                    <connections>
-                        <outlet property="currencyField" destination="Avp-M6-Khs" id="x5W-Qy-5d5"/>
-                        <outlet property="eventNameField" destination="p8z-RU-lL5" id="tHB-4u-p8r"/>
-                        <outlet property="revenueField" destination="9pM-0V-nEk" id="lll-Sd-3nu"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Oau-PG-0ct" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1625" y="-227"/>
+            <point key="canvasLocation" x="-1626.1538461538462" y="-227.48815165876775"/>
         </scene>
         <!--Identity-->
         <scene sceneID="xhf-6R-9I9">
             <objects>
                 <viewController id="OcW-9X-SqQ" customClass="IdentityController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="s5Y-Bh-IoZ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="756"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="singular_full_logo" translatesAutoresizingMaskIntoConstraints="NO" id="39G-yN-OSj">
-                                <rect key="frame" x="47" y="20" width="281" height="116"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="singular_full_logo" translatesAutoresizingMaskIntoConstraints="NO" id="C1M-dy-usi">
+                                <rect key="frame" x="47" y="20" width="296" height="128.33333333333334"/>
                             </imageView>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Custom User Id" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="FVL-AV-KHV">
-                                <rect key="frame" x="47" y="144" width="281" height="34"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter a UserID" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="FVL-AV-KHV">
+                                <rect key="frame" x="20" y="375.33333333333331" width="350" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="Qkz-kL-fmK"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KRo-sk-aoO">
-                                <rect key="frame" x="112" y="224" width="151" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Unset Custom User Id"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Data Privacy Options" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fVi-DR-oXj">
+                                <rect key="frame" x="20" y="158.33333333333334" width="350" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" systemColor="systemBlueColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Simulate Authentication" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X4n-eM-uy4">
+                                <rect key="frame" x="20" y="334.33333333333331" width="350" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" systemColor="systemBlueColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Device Info" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vcR-L5-bfc">
+                                <rect key="frame" x="20" y="503" width="350" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" systemColor="systemBlueColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GDPR / CCPA Age 13-16 Opt-Out" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g5W-2V-6eC">
+                                <rect key="frame" x="28.666666666666657" y="185.33333333333334" width="252.99999999999997" height="31"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Limited Data Sharing Opt-In" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vT0-a5-f8S">
+                                <rect key="frame" x="28.666666666666671" y="224.33333333333334" width="212.33333333333331" height="31"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="right" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="N1T-qY-pBE">
+                                <rect key="frame" x="310" y="185.33333333333334" width="51" height="31"/>
+                                <connections>
+                                    <action selector="gdpr:" destination="OcW-9X-SqQ" eventType="valueChanged" id="b5a-0L-BsY"/>
+                                </connections>
+                            </switch>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="right" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="KOw-Ny-BVI">
+                                <rect key="frame" x="310" y="224.33333333333334" width="51" height="31"/>
+                                <connections>
+                                    <action selector="limited_data_sharing:" destination="OcW-9X-SqQ" eventType="valueChanged" id="Xhi-WI-7ZH"/>
+                                </connections>
+                            </switch>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="right" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Jxj-Za-vVz">
+                                <rect key="frame" x="310" y="263.33333333333331" width="51" height="31"/>
+                                <connections>
+                                    <action selector="ccpa:" destination="OcW-9X-SqQ" eventType="valueChanged" id="Abd-JS-OBo"/>
+                                </connections>
+                            </switch>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CCPA Under Age 13 Opt-Out" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6IJ-6T-82d">
+                                <rect key="frame" x="28.666666666666657" y="263.33333333333331" width="273.33333333333337" height="31"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KRo-sk-aoO">
+                                <rect key="frame" x="310" y="415.33333333333331" width="60" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="cYU-Uv-jbN"/>
+                                </constraints>
+                                <state key="normal" title="Sign Out"/>
                                 <connections>
                                     <action selector="unsetCustomUserId:" destination="OcW-9X-SqQ" eventType="touchUpInside" id="cM6-sJ-Mgp"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TSM-hz-ID8">
-                                <rect key="frame" x="120" y="186" width="134" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Set Custom User Id"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="IDFA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sPS-Rk-vKi">
+                                <rect key="frame" x="20" y="573.33333333333337" width="350" height="19.333333333333371"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="idfa_value" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="4" translatesAutoresizingMaskIntoConstraints="NO" id="MAb-qV-BbU">
+                                <rect key="frame" x="20" y="597.66666666666663" width="350" height="18"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <color key="textColor" systemColor="placeholderTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="IDFV" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UJ6-u5-PDw">
+                                <rect key="frame" x="20" y="625.66666666666663" width="350" height="20"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ATT Status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="veY-01-jLV">
+                                <rect key="frame" x="20" y="544" width="79.666666666666671" height="19.333333333333371"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="att_value" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZDu-rz-Gte">
+                                <rect key="frame" x="107.66666666666666" y="544" width="262.33333333333337" height="19.333333333333371"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <color key="textColor" systemColor="placeholderTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="idfv_value" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="4" translatesAutoresizingMaskIntoConstraints="NO" id="kCF-yu-Vfi">
+                                <rect key="frame" x="20" y="650.66666666666663" width="350" height="18"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <color key="textColor" systemColor="placeholderTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TSM-hz-ID8">
+                                <rect key="frame" x="20" y="415.33333333333331" width="47" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="JI2-nt-P9r"/>
+                                </constraints>
+                                <state key="normal" title="Sign In"/>
                                 <connections>
                                     <action selector="setCustomUserId:" destination="OcW-9X-SqQ" eventType="touchUpInside" id="5m8-7i-FbW"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y9T-SR-Ym8">
+                                <rect key="frame" x="330" y="498.66666666666674" width="40" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="Jae-iy-oTk"/>
+                                </constraints>
+                                <state key="normal" title="Share"/>
+                                <connections>
+                                    <action selector="shareText:" destination="OcW-9X-SqQ" eventType="touchUpInside" id="qeM-48-MDw"/>
+                                </connections>
+                            </button>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="w7R-9t-bn8"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottomMargin" secondItem="kCF-yu-Vfi" secondAttribute="bottom" constant="38.333333333333485" id="2Nm-zD-29m"/>
+                            <constraint firstItem="w7R-9t-bn8" firstAttribute="trailing" secondItem="Y9T-SR-Ym8" secondAttribute="trailing" constant="20" id="4yv-kE-sid"/>
+                            <constraint firstItem="UJ6-u5-PDw" firstAttribute="top" secondItem="MAb-qV-BbU" secondAttribute="bottom" constant="10" id="6Q1-MN-I0A"/>
+                            <constraint firstItem="FVL-AV-KHV" firstAttribute="leading" secondItem="w7R-9t-bn8" secondAttribute="leading" constant="20" id="8Sf-Yc-mzP"/>
+                            <constraint firstItem="6IJ-6T-82d" firstAttribute="top" secondItem="vT0-a5-f8S" secondAttribute="bottom" constant="8" symbolic="YES" id="8ug-d5-ulP"/>
+                            <constraint firstItem="ZDu-rz-Gte" firstAttribute="leading" secondItem="veY-01-jLV" secondAttribute="trailing" constant="8" symbolic="YES" id="9IK-or-YB5"/>
+                            <constraint firstItem="w7R-9t-bn8" firstAttribute="trailing" secondItem="FVL-AV-KHV" secondAttribute="trailing" constant="20" id="9Ln-hp-miV"/>
+                            <constraint firstItem="veY-01-jLV" firstAttribute="centerY" secondItem="ZDu-rz-Gte" secondAttribute="centerY" id="9be-7K-Y7D"/>
+                            <constraint firstItem="X4n-eM-uy4" firstAttribute="leading" secondItem="w7R-9t-bn8" secondAttribute="leading" constant="20" id="A3M-nJ-vf4"/>
+                            <constraint firstItem="MAb-qV-BbU" firstAttribute="trailing" secondItem="sPS-Rk-vKi" secondAttribute="trailing" id="AxE-gX-pJ0"/>
+                            <constraint firstItem="vcR-L5-bfc" firstAttribute="leading" secondItem="veY-01-jLV" secondAttribute="leading" id="BC6-is-fAf"/>
+                            <constraint firstItem="6IJ-6T-82d" firstAttribute="bottom" secondItem="Jxj-Za-vVz" secondAttribute="bottom" id="CJo-B0-H0c"/>
+                            <constraint firstItem="w7R-9t-bn8" firstAttribute="trailing" secondItem="MAb-qV-BbU" secondAttribute="trailing" constant="20" id="E4m-1g-V6J"/>
+                            <constraint firstItem="vT0-a5-f8S" firstAttribute="top" secondItem="g5W-2V-6eC" secondAttribute="bottom" constant="8" symbolic="YES" id="Fi0-1F-9ED"/>
+                            <constraint firstItem="g5W-2V-6eC" firstAttribute="top" secondItem="N1T-qY-pBE" secondAttribute="top" id="GJm-Yo-rQN"/>
+                            <constraint firstItem="UJ6-u5-PDw" firstAttribute="leading" secondItem="w7R-9t-bn8" secondAttribute="leading" constant="20" id="Gly-5Y-Qh2"/>
+                            <constraint firstItem="X4n-eM-uy4" firstAttribute="top" secondItem="Jxj-Za-vVz" secondAttribute="bottom" constant="40" id="Gsq-Zb-Uc5"/>
+                            <constraint firstItem="ZDu-rz-Gte" firstAttribute="height" secondItem="veY-01-jLV" secondAttribute="height" id="Hmr-is-JcC"/>
+                            <constraint firstItem="g5W-2V-6eC" firstAttribute="bottom" secondItem="N1T-qY-pBE" secondAttribute="bottom" id="Im6-XV-a9R"/>
+                            <constraint firstItem="KRo-sk-aoO" firstAttribute="trailing" secondItem="FVL-AV-KHV" secondAttribute="trailing" id="Jkm-J2-Wbv"/>
+                            <constraint firstItem="Jxj-Za-vVz" firstAttribute="leading" secondItem="6IJ-6T-82d" secondAttribute="trailing" constant="8" symbolic="YES" id="JrA-Kz-Rwa"/>
+                            <constraint firstItem="KOw-Ny-BVI" firstAttribute="leading" secondItem="N1T-qY-pBE" secondAttribute="leading" id="KSr-26-X14"/>
+                            <constraint firstItem="w7R-9t-bn8" firstAttribute="trailing" secondItem="ZDu-rz-Gte" secondAttribute="trailing" constant="20" id="LPM-bR-3LQ"/>
+                            <constraint firstItem="Y9T-SR-Ym8" firstAttribute="centerY" secondItem="vcR-L5-bfc" secondAttribute="centerY" id="MJB-NA-QGA"/>
+                            <constraint firstItem="kCF-yu-Vfi" firstAttribute="top" secondItem="UJ6-u5-PDw" secondAttribute="bottom" constant="5" id="Oah-LL-p7Y"/>
+                            <constraint firstItem="6IJ-6T-82d" firstAttribute="leading" secondItem="vT0-a5-f8S" secondAttribute="leading" id="Qpe-W8-2zK"/>
+                            <constraint firstItem="ZDu-rz-Gte" firstAttribute="leading" secondItem="veY-01-jLV" secondAttribute="trailing" constant="8" symbolic="YES" id="Qzu-kC-4Ht"/>
+                            <constraint firstItem="veY-01-jLV" firstAttribute="top" secondItem="vcR-L5-bfc" secondAttribute="bottom" constant="20" id="RPI-OS-zV8"/>
+                            <constraint firstItem="MAb-qV-BbU" firstAttribute="leading" secondItem="sPS-Rk-vKi" secondAttribute="leading" id="S8A-XN-QY6"/>
+                            <constraint firstItem="6IJ-6T-82d" firstAttribute="top" secondItem="Jxj-Za-vVz" secondAttribute="top" id="SRq-rw-VeC"/>
+                            <constraint firstItem="FVL-AV-KHV" firstAttribute="leading" secondItem="X4n-eM-uy4" secondAttribute="leading" id="SSv-Jv-uU0"/>
+                            <constraint firstItem="w7R-9t-bn8" firstAttribute="trailing" secondItem="UJ6-u5-PDw" secondAttribute="trailing" constant="20" id="TGw-G3-2Dn"/>
+                            <constraint firstItem="MAb-qV-BbU" firstAttribute="top" secondItem="sPS-Rk-vKi" secondAttribute="bottom" constant="5" id="URu-JN-KMH"/>
+                            <constraint firstItem="TSM-hz-ID8" firstAttribute="leading" secondItem="FVL-AV-KHV" secondAttribute="leading" id="V2h-fe-rqI"/>
+                            <constraint firstItem="vcR-L5-bfc" firstAttribute="trailing" secondItem="KRo-sk-aoO" secondAttribute="trailing" id="V7y-fP-2pc"/>
+                            <constraint firstItem="FVL-AV-KHV" firstAttribute="trailing" secondItem="X4n-eM-uy4" secondAttribute="trailing" id="VgZ-wD-cPH"/>
+                            <constraint firstItem="N1T-qY-pBE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="g5W-2V-6eC" secondAttribute="trailing" constant="8" symbolic="YES" id="VkK-KN-jYc"/>
+                            <constraint firstItem="g5W-2V-6eC" firstAttribute="top" secondItem="fVi-DR-oXj" secondAttribute="bottom" constant="6" id="VlQ-Uh-0Hg"/>
+                            <constraint firstItem="vT0-a5-f8S" firstAttribute="bottom" secondItem="KOw-Ny-BVI" secondAttribute="bottom" id="Wk5-jy-pFX"/>
+                            <constraint firstItem="kCF-yu-Vfi" firstAttribute="leading" secondItem="UJ6-u5-PDw" secondAttribute="leading" id="Y24-tI-WnE"/>
+                            <constraint firstItem="kCF-yu-Vfi" firstAttribute="leading" secondItem="w7R-9t-bn8" secondAttribute="leading" constant="20" id="YKC-fA-cod"/>
+                            <constraint firstItem="kCF-yu-Vfi" firstAttribute="trailing" secondItem="vcR-L5-bfc" secondAttribute="trailing" id="Zu3-cI-pvb"/>
+                            <constraint firstItem="TSM-hz-ID8" firstAttribute="leading" secondItem="vcR-L5-bfc" secondAttribute="leading" id="c9c-NZ-pdh"/>
+                            <constraint firstItem="C1M-dy-usi" firstAttribute="leading" secondItem="w7R-9t-bn8" secondAttribute="leading" constant="47" id="cHT-4f-mC5"/>
+                            <constraint firstItem="fVi-DR-oXj" firstAttribute="centerX" secondItem="s5Y-Bh-IoZ" secondAttribute="centerX" id="cZT-B8-mt5"/>
+                            <constraint firstItem="vT0-a5-f8S" firstAttribute="top" secondItem="KOw-Ny-BVI" secondAttribute="top" id="df7-x5-gx6"/>
+                            <constraint firstItem="sPS-Rk-vKi" firstAttribute="leading" secondItem="w7R-9t-bn8" secondAttribute="leading" constant="20" id="dmP-Nv-yo6"/>
+                            <constraint firstItem="fVi-DR-oXj" firstAttribute="top" secondItem="C1M-dy-usi" secondAttribute="bottom" constant="10" id="ewx-UD-yfA"/>
+                            <constraint firstItem="Y9T-SR-Ym8" firstAttribute="height" secondItem="vcR-L5-bfc" secondAttribute="height" multiplier="1.42857" id="fBi-GM-XWB"/>
+                            <constraint firstItem="Jxj-Za-vVz" firstAttribute="leading" secondItem="KOw-Ny-BVI" secondAttribute="leading" id="fmt-iM-tGM"/>
+                            <constraint firstItem="w7R-9t-bn8" firstAttribute="trailing" secondItem="kCF-yu-Vfi" secondAttribute="trailing" constant="20" id="gbC-mo-qnJ"/>
+                            <constraint firstItem="sPS-Rk-vKi" firstAttribute="top" secondItem="veY-01-jLV" secondAttribute="bottom" constant="10" id="gem-Em-T8X"/>
+                            <constraint firstItem="TSM-hz-ID8" firstAttribute="top" secondItem="FVL-AV-KHV" secondAttribute="bottom" constant="10" id="hlH-HQ-V7A"/>
+                            <constraint firstItem="vcR-L5-bfc" firstAttribute="leading" secondItem="fVi-DR-oXj" secondAttribute="leading" id="i4e-cg-sD8"/>
+                            <constraint firstItem="w7R-9t-bn8" firstAttribute="trailing" secondItem="X4n-eM-uy4" secondAttribute="trailing" constant="20" id="i8f-8u-m5J"/>
+                            <constraint firstItem="MAb-qV-BbU" firstAttribute="leading" secondItem="w7R-9t-bn8" secondAttribute="leading" constant="20" id="iBR-1p-eCS"/>
+                            <constraint firstItem="w7R-9t-bn8" firstAttribute="trailing" secondItem="KRo-sk-aoO" secondAttribute="trailing" constant="20" id="jzt-Qt-EJa"/>
+                            <constraint firstItem="w7R-9t-bn8" firstAttribute="trailing" secondItem="C1M-dy-usi" secondAttribute="trailing" constant="47" id="ln2-M6-l2e"/>
+                            <constraint firstItem="kCF-yu-Vfi" firstAttribute="trailing" secondItem="UJ6-u5-PDw" secondAttribute="trailing" id="qeu-zQ-r96"/>
+                            <constraint firstItem="g5W-2V-6eC" firstAttribute="leading" secondItem="vT0-a5-f8S" secondAttribute="leading" id="qgp-RN-LTB"/>
+                            <constraint firstItem="UJ6-u5-PDw" firstAttribute="trailing" secondItem="MAb-qV-BbU" secondAttribute="trailing" id="quJ-r8-0hi"/>
+                            <constraint firstItem="KOw-Ny-BVI" firstAttribute="leading" secondItem="vT0-a5-f8S" secondAttribute="trailing" constant="69" id="s8b-eJ-XKR"/>
+                            <constraint firstItem="g5W-2V-6eC" firstAttribute="leading" secondItem="w7R-9t-bn8" secondAttribute="leading" constant="28.5" id="tdu-hj-gje"/>
+                            <constraint firstItem="FVL-AV-KHV" firstAttribute="top" secondItem="X4n-eM-uy4" secondAttribute="bottom" constant="20" id="v1k-bu-kXE"/>
+                            <constraint firstItem="kCF-yu-Vfi" firstAttribute="leading" secondItem="veY-01-jLV" secondAttribute="leading" id="wgk-8p-XNo"/>
+                            <constraint firstItem="C1M-dy-usi" firstAttribute="top" secondItem="w7R-9t-bn8" secondAttribute="top" constant="20" id="xPm-cs-t2D"/>
+                            <constraint firstItem="UJ6-u5-PDw" firstAttribute="leading" secondItem="MAb-qV-BbU" secondAttribute="leading" id="xmw-dg-8kl"/>
+                            <constraint firstItem="KRo-sk-aoO" firstAttribute="top" secondItem="FVL-AV-KHV" secondAttribute="bottom" constant="10" id="yC5-Zf-aCK"/>
+                            <constraint firstItem="w7R-9t-bn8" firstAttribute="trailing" secondItem="sPS-Rk-vKi" secondAttribute="trailing" constant="20" id="z3z-hv-Ipo"/>
+                        </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Identity" image="person.fill" catalog="system" selectedImage="person.fill" id="kZq-2e-2fu"/>
                     <connections>
+                        <outlet property="att_value" destination="ZDu-rz-Gte" id="Gcc-4f-Djj"/>
+                        <outlet property="ccpa" destination="Jxj-Za-vVz" id="4Me-nC-Kwq"/>
                         <outlet property="customUserIdField" destination="FVL-AV-KHV" id="f29-QH-k1T"/>
+                        <outlet property="gdpr" destination="N1T-qY-pBE" id="Abx-Lw-Dln"/>
+                        <outlet property="idfa_value" destination="MAb-qV-BbU" id="fm2-cr-M2d"/>
+                        <outlet property="idfv_value" destination="kCF-yu-Vfi" id="9WB-Qd-wvj"/>
+                        <outlet property="limited_data_sharing" destination="KOw-Ny-BVI" id="DjC-pZ-hoF"/>
+                        <outlet property="share" destination="Y9T-SR-Ym8" id="Ry1-uh-Pcp"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cBI-XJ-WDP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1626" y="-985"/>
+            <point key="canvasLocation" x="-1344.6153846153845" y="-986.01895734597156"/>
         </scene>
     </scenes>
     <resources>
-        <image name="dollarsign.circle.fill" catalog="system" width="64" height="60"/>
-        <image name="link" catalog="system" width="64" height="58"/>
-        <image name="pencil" catalog="system" width="64" height="56"/>
-        <image name="person.fill" catalog="system" width="64" height="60"/>
-        <image name="singular_full_logo" width="786.5" height="192.5"/>
+        <image name="dollarsign.circle.fill" catalog="system" width="128" height="121"/>
+        <image name="link" catalog="system" width="128" height="122"/>
+        <image name="pencil" catalog="system" width="128" height="113"/>
+        <image name="person.fill" catalog="system" width="128" height="120"/>
+        <image name="singular_full_logo" width="524.33331298828125" height="128.33332824707031"/>
+        <systemColor name="linkColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="placeholderTextColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/ios-sample-app/ios-sample-app/Constants.h
+++ b/ios-sample-app/ios-sample-app/Constants.h
@@ -2,12 +2,17 @@
 //  Constants.h
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 21/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
-#define APIKEY @"<YOUR_API_KEY>"
-#define SECRET @"<YOUR_SECRET>"
+// Get keys from https://app.singular.net/?#/sdk
+#define APIKEY @"ADD_SDK_APIKEY_HERE"
+#define SECRET @"ADD_SDK_SECRET_HERE"
+
+// Add email provider ESP tracking domain support
+//#define ESPDOMAIN @"links.mydomain.com"
 
 #define DEEPLINK @"deeplink"
 #define PASSTHROUGH @"passthrough"

--- a/ios-sample-app/ios-sample-app/Controllers/CustomEventsController.h
+++ b/ios-sample-app/ios-sample-app/Controllers/CustomEventsController.h
@@ -2,16 +2,18 @@
 //  CustomEventsController.h
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 19/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
-
 #import <UIKit/UIKit.h>
 
 @interface CustomEventsController : UIViewController
 
-@property (strong, nonatomic) IBOutlet UITextField *eventNameField;
 - (IBAction)sendEvent:(id)sender;
-- (IBAction)sendEventsWithAttributes:(id)sender;
+
+- (IBAction)sendEventWithArgs:(id)sender;
+
+- (IBAction)sendEventsWithArgsWithDictionary:(id)sender;
 
 @end

--- a/ios-sample-app/ios-sample-app/Controllers/CustomEventsController.m
+++ b/ios-sample-app/ios-sample-app/Controllers/CustomEventsController.m
@@ -2,8 +2,9 @@
 //  CustomEventsController.m
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 19/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import "CustomEventsController.h"
@@ -13,43 +14,47 @@
 @implementation CustomEventsController
 
 - (IBAction)sendEvent:(id)sender {
-    NSString* eventName =self.eventNameField.text;
-    
-    if([Utils isEmptyOrNull:eventName]){
-        [Utils displayMessage:@"Please enter a valid event name" withView:self];
-        return;
-    }
+    NSString* eventName = @"ViewItem";
     
     // Set Conversion Value manually (when using manualSkanConversionManagement)
     // Note that conversion values may only increase, so only the first call will update it
-    [Singular skanUpdateConversionValue:7];
+    //[Singular skanUpdateConversionValue:7];
     
     // Reporting a simple event to Singular
     [Singular event:eventName];
-    
     [Utils displayMessage:@"Event sent" withView:self];
 }
 
-- (IBAction)sendEventsWithAttributes:(id)sender {
-    NSString* eventName =self.eventNameField.text;
+- (IBAction)sendEventWithArgs:(id)sender {
+    NSString* eventName = @"ViewItem_WithArgs";
+    NSString* sku = @"12345";
+    NSString* price = @"123.45";
+        
+    // Set Conversion Value manually (when using manualSkanConversionManagement)
+    // Note that conversion values may only increase, so only the first call will update it
+    //[Singular skanUpdateConversionValue:7];
     
-     if([Utils isEmptyOrNull:eventName]){
-         [Utils displayMessage:@"Please enter a valid event name" withView:self];
-        return;
-    }
+    // Reporting a simple event with Arguments to Singular
+    [Singular eventWithArgs:eventName, @"sku", sku, @"price", price, nil];
+    [Utils displayMessage:@"ViewItem_WithArgs sent" withView:self];
+}
+
+
+- (IBAction)sendEventsWithArgsWithDictionary:(id)sender {
+    NSString* eventName = @"ViewItem_WithDictionary";
     
     NSMutableDictionary* args = [[NSMutableDictionary alloc] init];
     [args setObject:@"value1" forKey:@"key1"];
     [args setObject:@"value2" forKey:@"key2"];
+    [args setObject:@"value3" forKey:@"key3"];
     
     // Set Conversion Value manually (when using manualSkanConversionManagement)
     // Note that conversion values may only increase, so only the first call will update it
-    [Singular skanUpdateConversionValue:3];
+    //[Singular skanUpdateConversionValue:3];
     
-    // Reporting a simple event with your custom attributes to pass with the event
+    // Reporting a simple event with Arguments in a Dictionary
     [Singular event:eventName withArgs:args];
-    
-    [Utils displayMessage:@"Event sent" withView:self];
+    [Utils displayMessage:@"ViewItem_WithDictionary sent" withView:self];
 }
 
 @end

--- a/ios-sample-app/ios-sample-app/Controllers/DeeplinkController.h
+++ b/ios-sample-app/ios-sample-app/Controllers/DeeplinkController.h
@@ -2,8 +2,9 @@
 //  DeeplinkController.h
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 20/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/ios-sample-app/ios-sample-app/Controllers/DeeplinkController.m
+++ b/ios-sample-app/ios-sample-app/Controllers/DeeplinkController.m
@@ -2,8 +2,9 @@
 //  DeeplinkController.m
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 20/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import "DeeplinkController.h"
@@ -34,6 +35,7 @@
     [self.deeplinkField setText:[deeplinkData objectForKey:DEEPLINK]];
     [self.passthroughField setText:[deeplinkData objectForKey:PASSTHROUGH]];
     [self.isDeferredField setText:[deeplinkData objectForKey:IS_DEFERRED] ? @"Yes" : @"No"];
+
 }
 
 @end

--- a/ios-sample-app/ios-sample-app/Controllers/IdentityController.h
+++ b/ios-sample-app/ios-sample-app/Controllers/IdentityController.h
@@ -2,14 +2,39 @@
 //  IdentifyController.h
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 01/12/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>
 
-@interface IdentityController : UIViewController
+
+@interface IdentityController : UIViewController 
+
+@property (weak, nonatomic) NSString *custom_user_id;
+@property (weak, nonatomic) NSString *att_state;
+@property (weak, nonatomic) NSString *s_idfa;
+@property (weak, nonatomic) NSString *s_idfv;
+@property (weak, nonatomic) NSString *shareMessage;
 
 @property (weak, nonatomic) IBOutlet UITextField *customUserIdField;
+@property (weak, nonatomic) IBOutlet UILabel *idfa_value;
+@property (weak, nonatomic) IBOutlet UILabel *idfv_value;
+@property (weak, nonatomic) IBOutlet UILabel *att_value;
+
+@property (weak, nonatomic) IBOutlet UISwitch *gdpr;
+@property (weak, nonatomic) IBOutlet UISwitch *limited_data_sharing;
+@property (weak, nonatomic) IBOutlet UISwitch *ccpa;
+@property (weak, nonatomic) IBOutlet UIButton *share;
+
+
+- (IBAction)gdpr:(UISwitch *)sender;
+- (IBAction)limited_data_sharing:(UISwitch *)sender;
+- (IBAction)ccpa:(UISwitch *)sender;
+
+- (IBAction)shareText:(id)sender;
+
+- (void)presentActivityController:(UIActivityViewController *)shareController;
 
 @end

--- a/ios-sample-app/ios-sample-app/Controllers/IdentityController.m
+++ b/ios-sample-app/ios-sample-app/Controllers/IdentityController.m
@@ -2,13 +2,17 @@
 //  IdentifyController.m
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 01/12/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import "IdentityController.h"
 #import "Singular.h"
 #import "Utils.h"
+#import "AppDelegate.h"
+#import <AppTrackingTransparency/ATTrackingManager.h>
+#import <AdSupport/ASIdentifierManager.h>
 
 @interface IdentityController ()
 
@@ -16,27 +20,154 @@
 
 @implementation IdentityController
 
-- (void)viewDidLoad {
+- (void)viewDidLoad{
     [super viewDidLoad];
+    [self requestTrackingAuthorization];
 }
 
-- (IBAction)setCustomUserId:(id)sender {
-    NSString* customUserId = self.customUserIdField.text;
+- (IBAction)gdpr:(UISwitch *)sender {
+    if (self.gdpr.isOn){
+        [Singular event:@"GDPR_CCPA_OptOut"];
+        [Singular stopAllTracking];
+        NSLog(@"GDPR_CCPA Tracking OptOut - Tracking Stopped");
+    } else {
+        //[Singular trackingOptIn];
+        if ([Singular isAllTrackingStopped] == TRUE){
+            [Singular resumeAllTracking];
+            [Singular event:@"GDPR_CCPA_OptIn"];
+            NSLog(@"GDPR_CCPA Tracking OptIn");
+        }
+    }
+}
+
+- (IBAction)limited_data_sharing:(UISwitch *)sender {
+    if (self.limited_data_sharing.isOn){
+        [Singular limitDataSharing:YES];
+        [Singular event:@"LimitedDataSharing_OptIn"];
+        NSLog(@"Limited Data Sharing OptIn");
+    } else {
+        [Singular limitDataSharing:NO];
+        [Singular event:@"LimitedDataSharing_OptOut"];
+        NSLog(@"Limited Data Sharing OptOut");
+        }
+}
+
+- (IBAction)ccpa:(UISwitch *)sender {
+    if (self.ccpa.isOn){
+        [Singular event:@"CCPA_AgeUnder13_OptOut"];
+        [Singular stopAllTracking];
+        NSLog(@"CCPA OptOut SDK Tracking Stopped");
+    } else {
+        [Singular resumeAllTracking];
+        [Singular event:@"CCPA_Disabled"];
+        NSLog(@"CCPA Disabled SDK Tracking Started");
+        }
+}
+
+- (IBAction)shareText:(id)sender {
+    // create a share message
+    AppDelegate *DataDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
+    NSString* sharedText = DataDelegate.sharedMessage;
+    NSArray *items = @[ sharedText ];
     
-    if([Utils isEmptyOrNull:customUserId]){
+    // build an activity view controller and present it
+    UIActivityViewController *shareController = [[UIActivityViewController alloc]initWithActivityItems:items applicationActivities:nil];
+    [self presentActivityController:shareController];
+}
+
+- (void)presentActivityController:(UIActivityViewController *)shareController {
+    // for iPad: make the presentation a Popover
+    shareController.modalPresentationStyle = UIModalPresentationPopover;
+    [self presentViewController:shareController animated:YES completion:nil];
+
+    UIPopoverPresentationController *popController = [shareController popoverPresentationController];
+    popController.permittedArrowDirections = UIPopoverArrowDirectionAny;
+    popController.barButtonItem = self.navigationItem.leftBarButtonItem;
+
+    // access the completion handler
+    shareController.completionWithItemsHandler = ^(NSString *activityType,
+                                              BOOL completed,
+                                              NSArray *returnedItems,
+                                              NSError *error){
+        // react to the completion
+        if (completed) {
+
+            // user shared an item
+            NSLog(@"We used activity type%@", activityType);
+
+        } else {
+
+            // user cancelled
+            NSLog(@"We didn't want to share anything after all.");
+        }
+
+        if (error) {
+            NSLog(@"An Error occured: %@, %@", error.localizedDescription, error.localizedFailureReason);
+        }
+    };
+}
+
+
+- (IBAction)setCustomUserId:(id)sender {
+    self.custom_user_id = self.customUserIdField.text;
+    
+    if([Utils isEmptyOrNull:self.custom_user_id]){
         [Utils displayMessage:@"Please enter a valid Custom User Id" withView:self];
     }
     
-    // Once set, the Custom User Id will persist between runs until `[Singular unsetCustomUserId]` is called.
-    // This can also be called before SDK init if you want the first session to include the Custom User Id.
-    [Singular setCustomUserId:customUserId];
-
-    [Utils displayMessage:[[NSString alloc] initWithFormat:@"Custom User Id set to: %@", customUserId] withView:self];
+    if ([self.custom_user_id length] > 0){
+        // Once set, the Custom User Id will persist between runs until `[Singular unsetCustomUserId]` is called.
+        // This can also be called before SDK init if you want the first session to include the Custom User Id.
+        [Singular setCustomUserId:self.custom_user_id];
+        [Singular event:@"SignIn_Success"];
+        [Utils displayMessage:[[NSString alloc] initWithFormat:@"SignIn Success!\nwith Custom User Id set to: %@", self.custom_user_id] withView:self];
+    }
 }
 
 - (IBAction)unsetCustomUserId:(id)sender {
-    [Singular unsetCustomUserId];
-    [Utils displayMessage:@"Custom User Id unset" withView:self];
+    if ([self.custom_user_id length] > 0){
+        // Once set, the Custom User Id will persist between runs until `[Singular unsetCustomUserId]` is called.
+        // This can also be called before SDK init if you want the first session to include the Custom User Id.
+        [Singular unsetCustomUserId];
+        [Singular event:@"SignOut"];
+        [Utils displayMessage:@"SignOut\nUserID unassociated with device" withView:self];
+    } else {
+        [Utils displayMessage:[[NSString alloc] initWithFormat:@"User not Signed In"] withView:self];
+    }
+    
 }
+
+- (void)requestTrackingAuthorization {
+    AppDelegate *DataDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
+    // call requestTrackingAuthorizationWithCompletionHandler from ATTrackingManager to start the user consent process
+    if (@available(iOS 14, *)) {
+        NSLog(@"\n**** - iOS 14 requestTrackingAuthorization - ****\n");
+        [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
+            // Tracking authorization completed. Start loading ads here.
+            switch (status) {
+                case 0: self.att_state = @"(0) Not Determined";
+                case 1: self.att_state = @"(1) Restricted";
+                case 2: self.att_state = @"(2) Denied";
+                case 3: self.att_state = @"(3) Authorized";
+                }
+            self.s_idfa = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+            self.s_idfv = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
+            NSLog(@"IDFA: %@", self.s_idfa);
+            NSLog(@"IDFV: %@", self.s_idfv);
+            NSLog(@"ATT Status: %lu", (unsigned long)status);
+            //NSLog(@"Limited Ad Tracking (pre iOS14): %d", [[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled]);
+            [self.idfa_value setText:self.s_idfa];
+            [self.idfv_value setText:self.s_idfv];
+            [self.att_value setText:self.att_state];
+            DataDelegate.sharedMessage = [NSString stringWithFormat:@"Sample App Device Info:\n\nAdvertising ID (IDFA): %@ \n\nIDFV: %@",self.s_idfa,self.s_idfv];
+          }];
+    } else {
+        [self.idfa_value setText:[[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString]];
+        [self.idfv_value setText:[[[UIDevice currentDevice] identifierForVendor] UUIDString]];
+        [self.att_value setText:@"(0) Not Determined < iOS14"];
+    }
+}
+
+
 
 @end

--- a/ios-sample-app/ios-sample-app/Controllers/RevenueController.h
+++ b/ios-sample-app/ios-sample-app/Controllers/RevenueController.h
@@ -2,19 +2,27 @@
 //  RevenueController.h
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 19/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>
 
-@interface RevenueController : UIViewController<UIPickerViewDataSource, UIPickerViewDelegate>{
-    NSArray* pickerData;
-}
+@interface RevenueController : UIViewController
 
-@property (strong, nonatomic) IBOutlet UITextField *eventNameField;
-@property (strong, nonatomic) IBOutlet UITextField *currencyField;
-@property (strong, nonatomic) IBOutlet UITextField *revenueField;
-@property (strong, nonatomic) IBOutlet UIPickerView *currencyPicker;
+- (IBAction)send_iapCompleteEvent:(id)sender;
+
+- (IBAction)send_iapCompleteWithNameEvent:(id)sender;
+
+- (IBAction)sendRevenueEvent:(id)sender;
+
+- (IBAction)sendRevenueWithProductDetailsEvent:(id)sender;
+
+- (IBAction)sendCustomRevenueEvent:(id)sender;
+
+- (IBAction)sendCustomRevenueWithProductDetailsEvent:(id)sender;
+
+- (IBAction)sendRevenueEventWithArgs:(id)sender;
 
 @end

--- a/ios-sample-app/ios-sample-app/Controllers/RevenueController.m
+++ b/ios-sample-app/ios-sample-app/Controllers/RevenueController.m
@@ -2,8 +2,9 @@
 //  RevenueController.m
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 19/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import "RevenueController.h"
@@ -14,114 +15,91 @@
 
 - (void)viewDidLoad{
     [super viewDidLoad];
+}
+
+- (IBAction)send_iapCompleteEvent:(id)sender {
+    // Send a transaction event to Singular with the transaction receipt.
     
-    pickerData = @[@"EUR",@"GBP",@"ILS",@"INR",@"JPY",@"KRW",@"USD"];
+    //SKPaymentTransaction* transaction = ...;
+    //[Singular iapComplete:transaction];
+    [Utils displayMessage:@"iapComplete Event \nrequires SKPaymentTransaction" withView:self];
+}
+
+- (IBAction)send_iapCompleteWithNameEvent:(id)sender {
+    // Send a transaction event to Singular with a custom name for the event
+    
+    //[Singular iapComplete:transaction withName:@"MyCustomRevenue"];
+    [Utils displayMessage:@"iapCompleteWithName Event \nrequires SKPaymentTransaction" withView:self];
 }
 
 - (IBAction)sendRevenueEvent:(id)sender {
-    NSString* eventName = self.eventNameField.text;
-    NSString* currency = self.currencyField.text;
-    double revenue = [self getRevenue];
+    // Settig the Event Name, Currency, and total revenue amount for the event
+    NSString* currency = @"USD";
+    double revenue = 1.99;
     
-    if([Utils isEmptyOrNull:eventName]){
-        [Utils displayMessage:@"Please enter a valid event name" withView:self];
-        return;
-    }
+    // Reporting a simple revenue event to Singular will send __iap__ revenue event with no attributes
+    [Singular revenue:currency amount:revenue];
+    [Utils displayMessage:@"IAP Revenue Event sent" withView:self];
+}
+
+- (IBAction)sendRevenueWithProductDetailsEvent:(id)sender {
+    // Reporting a simple revenue event to Singular with product details
+    NSString* currency = @"USD";
+    double revenue = 5.00;
+    NSString* productSKU = @"SKU1928375";
+    NSString* productName = @"Reservation Fee";
+    NSString* productCategory = @"Fee";
+    int productQuantity = 1;
+    double productPrice = 5.00;
     
-    if([Utils isEmptyOrNull:currency]){
-        [Utils displayMessage:@"Please enter a valid currency" withView:self];
-        return;
-    }
-    
-    if(revenue <= 0){
-        [Utils displayMessage:@"Revenue can't be zero or empty" withView:self];
-        return;
-    }
+    // Reporting a simple revenue event to Singular will send __iap__ revenue event with no attributes
+    [Singular revenue:currency amount:revenue productSKU:productSKU productName:productName productCategory:productCategory productQuantity:productQuantity productPrice:productPrice];
+    [Utils displayMessage:@"Revenue Event\nwith product details\nsent" withView:self];
+}
+
+- (IBAction)sendCustomRevenueEvent:(id)sender {
+    // Setting the Event Name, Currency, and total revenue amount for the event
+    NSString* eventName = @"CustomRevenue";
+    NSString* currency = @"USD";
+    double revenue = 1.99;
     
     // Reporting a simple revenue event to Singular
     [Singular customRevenue:eventName currency:currency amount:revenue];
+    [Utils displayMessage:@"CustomRevenue Event sent" withView:self];
+}
+
+- (IBAction)sendCustomRevenueWithProductDetailsEvent:(id)sender {
+    // Reporting a simple revenue event to Singular with product details
+    NSString* eventName = @"MyCustomRevenue";
+    NSString* currency = @"USD";
+    double revenue = 5.00;
+    NSString* productSKU = @"SKU1928375";
+    NSString* productName = @"Reservation Fee";
+    NSString* productCategory = @"Fee";
+    int productQuantity = 1;
+    double productPrice = 5.00;
     
-    [Utils displayMessage:@"Revenue event sent" withView:self];
+    // Reporting a Custom revenue event to Singular with Product Details
+    [Singular customRevenue:eventName currency:currency amount:revenue productSKU:productSKU productName:productName productCategory:productCategory productQuantity:productQuantity productPrice:productPrice];
+    
+    [Utils displayMessage:@"Custom Revenue Event\nwith product details\nsent" withView:self];
 }
 
 - (IBAction)sendRevenueEventWithArgs:(id)sender {
-    NSString* eventName = self.eventNameField.text;
-    NSString* currency = self.currencyField.text;
-    double revenue = [self getRevenue];
+    // Settig the Event Name, Currency, and total revenue amount for the event
+    NSString* eventName = @"CustomRevenueWithArgs";
+    NSString* currency = @"USD";
+    double revenue = 19.99;
     
-    if([Utils isEmptyOrNull:eventName]){
-        [Utils displayMessage:@"Please enter a valid event name" withView:self];
-        return;
-    }
-    
-    if([Utils isEmptyOrNull:currency]){
-        [Utils displayMessage:@"Please enter a valid currency" withView:self];
-        return;
-    }
-    
-    if(revenue <= 0){
-        [Utils displayMessage:@"Revenue must be a number greater than 0" withView:self];
-        return;
-    }
-    
-    // Reporting a simple revenue event with your custom attributes to pass with the event
+    // Adding your custom revenue arguments into a dictionary
     NSMutableDictionary* args = [[NSMutableDictionary alloc] init];
     [args setObject:@"value1" forKey:@"key1"];
     [args setObject:@"value2" forKey:@"key2"];
+    [args setObject:@"value3" forKey:@"key3"];
     
     [Singular customRevenue:eventName currency:currency amount:revenue withAttributes:args];
-    [Utils displayMessage:@"Revenue event sent" withView:self];
+    [Utils displayMessage:@"CustomRevenueWithArgs event sent" withView:self];
 }
 
-- (double)getRevenue{
-    if ([Utils isEmptyOrNull:self.revenueField.text]){
-        return 0;
-    }
-    
-    return [self.revenueField.text doubleValue];
-}
-
-// Currency Picker logic
-- (NSInteger)numberOfComponentsInPickerView:(nonnull UIPickerView *)pickerView {
-    return 1;
-}
-
-- (NSInteger)pickerView:(nonnull UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component {
-    return pickerData.count;
-}
-
-- (NSString*)pickerView:(UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(NSInteger)component{
-    return pickerData[row];
-}
-
-- (IBAction)showCurrencyPicker:(id)sender {
-    self.currencyPicker = [[UIPickerView alloc] init];
-    self.currencyPicker.dataSource = self;
-    self.currencyPicker.delegate = self;
-    
-    UIToolbar* toolbar = [[UIToolbar alloc] init];
-    toolbar.barStyle = UIBarStyleBlack;
-    toolbar.translucent = YES;
-    [toolbar sizeToFit];
-    
-    // Aligns the done button to the right
-    UIBarButtonItem *flexibleSpaceLeft = [[UIBarButtonItem alloc]
-                                          initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
-    
-    UIBarButtonItem* doneButton = [[UIBarButtonItem alloc] initWithTitle:@"Done"
-                                                                   style:UIBarButtonItemStyleDone target:self
-                                                                  action:@selector(doneClicked:)];
-    
-    [toolbar setItems:[NSArray arrayWithObjects:flexibleSpaceLeft, doneButton, nil]];
-    
-    self.currencyField.inputView = self.currencyPicker;
-    self.currencyField.inputAccessoryView = toolbar;
-}
-
--(void)doneClicked:(id)sender{
-    [self.currencyField resignFirstResponder];
-    NSString* currency = [self pickerView:self.currencyPicker titleForRow:[self.currencyPicker selectedRowInComponent:0] forComponent:0];
-    [self.currencyField setText:currency];
-}
 
 @end

--- a/ios-sample-app/ios-sample-app/Controllers/TabController.h
+++ b/ios-sample-app/ios-sample-app/Controllers/TabController.h
@@ -2,8 +2,9 @@
 //  MainTabController.h
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 20/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/ios-sample-app/ios-sample-app/Controllers/TabController.m
+++ b/ios-sample-app/ios-sample-app/Controllers/TabController.m
@@ -2,8 +2,9 @@
 //  MainTabController.m
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 20/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import "TabController.h"
@@ -16,7 +17,7 @@
 
 -(void)openedWithDeeplink{
     // Display the DeeplinkController
-    [self setSelectedIndex:3];
+    [self setSelectedIndex:1];
 }
 
 // Minimizes the keyboard when it's not needed

--- a/ios-sample-app/ios-sample-app/Info.plist
+++ b/ios-sample-app/ios-sample-app/Info.plist
@@ -2,10 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSUserTrackingUsageDescription</key>
-	<string>This is a message you can customize in the info.plist file</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ObjC Sample App</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -17,11 +17,36 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>ios.sample.app.objc</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>singularsample</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Allow tracking for a tailored experience.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -33,8 +58,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/ios-sample-app/ios-sample-app/Utils.h
+++ b/ios-sample-app/ios-sample-app/Utils.h
@@ -2,8 +2,9 @@
 //  Utils.h
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 21/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/ios-sample-app/ios-sample-app/Utils.m
+++ b/ios-sample-app/ios-sample-app/Utils.m
@@ -2,8 +2,9 @@
 //  Utils.m
 //  ios-sample-app
 //
-//  Created by Eyal Rabinovich on 21/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Created by Eyal Rabinovich on 13/11/2019.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import "Utils.h"

--- a/ios-sample-app/ios-sample-app/iOS Sample App.entitlements
+++ b/ios-sample-app/ios-sample-app/iOS Sample App.entitlements
@@ -2,9 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:sample.sng.link</string>
+		<string>applinks:se.sng.link</string>
 	</array>
 </dict>
 </plist>

--- a/ios-sample-app/ios-sample-app/main.m
+++ b/ios-sample-app/ios-sample-app/main.m
@@ -3,7 +3,8 @@
 //  ios-sample-app
 //
 //  Created by Eyal Rabinovich on 13/11/2019.
-//  Copyright © 2019 Singular Labs. All rights reserved.
+//  Updated by Jared Ornstead on 2021/11/07
+//  Copyright © 2021 Singular Labs. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>
@@ -11,9 +12,14 @@
 
 int main(int argc, char * argv[]) {
     NSString * appDelegateClassName;
+    printf("**** - In MAIN - ****\n");
     @autoreleasepool {
         // Setup code that might create autoreleased objects goes here.
         appDelegateClassName = NSStringFromClass([AppDelegate class]);
     }
+    
     return UIApplicationMain(argc, argv, nil, appDelegateClassName);
+    
+    
+    
 }


### PR DESCRIPTION
There are a lot of changes here:

- Updated to latest SDK 11.0.1
- Added ESP Domain Support
- Updated Deeplink Handler as there was an error with nil crashing the app when no passthrough was provided
- Updated AppDelegate to use the SingularConfig on all entry points
- Added examples of: implementing ATT, Uninstall, support for non-singular links, revenue events with args(using dictionary), data privacy options (gdpr, ccpa, age-gate methods), and displayed the identifiers with share option.

This is a working IPA that can be used for testing: [IPA](https://drive.google.com/file/d/1cI5muGv8qfnB8HX1wWDIPfZuGXLT6gzS/view?usp=sharing)

These are deeplinks that can be used for testing: 
Tracking Link1: [Link1](https://se.sng.link/Cjdwd/fuw1?_smtype=3&_dl=singularsample%3A%2F%2Fhome&_p=FirstLink)
Tracking Link2: [Link2](https://se.sng.link/Cjdwd/fuw1?_smtype=3&_dl=singularsample%3A%2F%2Fdetails&_p=SecondLink)

Screenshots:

Added ATT Prompt:
![image](https://user-images.githubusercontent.com/29433802/140969281-78d8de0e-ef1f-46d7-889f-9cc6754cda51.png)

Data Privacy Examples, Authentication, and Device Info with Share:
![image](https://user-images.githubusercontent.com/29433802/140969457-272aafd8-1896-4c1a-beeb-cf75a41d362f.png)

Additional Event Options:
![image](https://user-images.githubusercontent.com/29433802/140969508-74d3f60c-8322-4abd-b099-299099c61c05.png)

Additional Revenue Options:
![image](https://user-images.githubusercontent.com/29433802/140969372-2fd85a46-9e19-48e7-bb83-c06ac1e941c8.png)
